### PR TITLE
More consistent style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,7 @@
 # This .clang-format file is tested with clang-format 4.0.0
-# and does not yield the desired style due to bugs or missing
-# features of clang-format. However, if you do not consider
-# macros, the result is pretty close to the desired snowhouse
-# style.
 #
 # Please use
 #   clang-format -style=file -i <your files...>
-# and check with
-#   git add -p
 # before committing your changes.
 ---
 Language: Cpp
@@ -80,8 +74,6 @@ IncludeCategories:
 
 # AlignEscapedNewlinesLeft: false
 # XXX: There should be no alignment at all, but this is not available
-
-# FixNamespaceComments: false
 
 AlwaysBreakAfterReturnType: None
 

--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ AccessModifierOffset: -2
 NamespaceIndentation: All
 IndentCaseLabels: false
 ContinuationIndentWidth: 4
-ConstructorInitializerIndentWidth: 2
+ConstructorInitializerIndentWidth: 4
 IndentWrappedFunctionNames: false
 
 AlwaysBreakTemplateDeclarations: true

--- a/.clang-format
+++ b/.clang-format
@@ -46,9 +46,7 @@ AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Empty
-# XXX: This does not work correctly since BraceWrapping::AfterFunction is true
-# XXX: Also empty classes should be one a single line, this is not supported.
+AllowShortFunctionsOnASingleLine: None
 
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,8 @@
 # This .clang-format file is tested with clang-format 4.0.0
 # and does not yield the desired style due to bugs or missing
 # features of clang-format. However, if you do not consider
-# macros or empty function/class bodies, the result is pretty
-# close to the desired snowhouse style.
+# macros, the result is pretty close to the desired snowhouse
+# style.
 #
 # Please use
 #   clang-format -style=file -i <your files...>

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+# This .clang-format file is tested with clang-format 4.0.0
+# and does not yield the desired style due to bugs or missing
+# features of clang-format. However, if you do not consider
+# macros or empty function/class bodies, the result is pretty
+# close to the desired snowhouse style.
+#
+# Please use
+#   clang-format -style=file -i <your files...>
+# and check with
+#   git add -p
+# before committing your changes.
+---
+Language: Cpp
+Standard: Cpp03
+
+ColumnLimit: 0
+IndentWidth: 2
+UseTab: Never
+AccessModifierOffset: -2
+NamespaceIndentation: All
+IndentCaseLabels: false
+ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 2
+IndentWrappedFunctionNames: false
+
+AlwaysBreakTemplateDeclarations: true
+SpaceAfterTemplateKeyword: false
+
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterNamespace: false
+  AfterStruct: true
+  AfterClass: true
+  AfterFunction: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+# XXX: This does not work correctly since BraceWrapping::AfterFunction is true
+# XXX: Also empty classes should be one a single line, this is not supported.
+
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+
+SpacesInParentheses: false
+SpaceInEmptyParentheses: false
+SpacesInSquareBrackets: false
+SpacesInAngles: false
+SpaceAfterCStyleCast: false
+SpacesInCStyleCastParentheses: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesBeforeTrailingComments: 1
+SpacesInContainerLiterals: false
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+
+SortIncludes: false
+IncludeCategories:
+  - Regex:           'snowhouse/'
+    Priority:        2
+  - Regex:           '^<'
+    Priority:        1
+  - Regex:           '.*'
+    Priority:        3
+# XXX: There is no need to sort includes alphabetically,
+# but standard library includes should come before snowhouse
+# includes should come before local includes.
+
+# AlignEscapedNewlinesLeft: false
+# XXX: There should be no alignment at all, but this is not available
+
+# FixNamespaceComments: false
+
+AlwaysBreakAfterReturnType: None
+
+ReflowComments: false

--- a/.clang-format
+++ b/.clang-format
@@ -31,7 +31,7 @@ PointerAlignment: Left
 
 BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterNamespace: false
+  AfterNamespace: true
   AfterStruct: true
   AfterClass: true
   AfterFunction: true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ been extracted to be usable in other contexts.
 
 ```C++
 #include <snowhouse/snowhouse.h>
+
 using namespace snowhouse;
 
 int main()

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ struct within_delta
   }
 
 private:
-    int delta_;
+  int delta_;
 };
 
 AssertThat(container1, Is().EqualToContainer(container1, within_delta(1));

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -2,11 +2,13 @@
 #include "tests.h"
 using namespace snowhouse;
 
-void throwRuntimeError() {
+void throwRuntimeError()
+{
   throw std::runtime_error("This is expected");
 }
 
-struct IgnoreErrors {
+struct IgnoreErrors
+{
   template<typename ExpectedType, typename ActualType>
   static void Handle(const ExpectedType&, const ActualType&, const char*, int)
   {

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -188,7 +188,7 @@ void BasicAssertions()
   it("handles !IsNull()");
   {
     int anInt = 0;
-    AssertThat(&anInt, ! IsNull());
+    AssertThat(&anInt, !IsNull());
   }
 
   it("detects when IsNull() fails (real address)");
@@ -212,7 +212,7 @@ void BasicAssertions()
     std::ostringstream message;
     message << "Expected: not equal to nullptr\nActual: nullptr\n";
 
-    AssertTestFails(AssertThat(nullptr, ! IsNull()), message.str());
+    AssertTestFails(AssertThat(nullptr, !IsNull()), message.str());
   }
 #endif
 }

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -10,9 +10,13 @@ void throwRuntimeError()
 struct IgnoreErrors
 {
   template<typename ExpectedType, typename ActualType>
-  static void Handle(const ExpectedType&, const ActualType&, const char*, int) {}
+  static void Handle(const ExpectedType&, const ActualType&, const char*, int)
+  {
+  }
 
-  static void Handle(const std::string&) {}
+  static void Handle(const std::string&)
+  {
+  }
 };
 
 void BasicAssertions()

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -1,5 +1,7 @@
 #include <stdexcept>
+
 #include "tests.h"
+
 using namespace snowhouse;
 
 void throwRuntimeError()

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -80,7 +80,7 @@ void BasicAssertions()
     {
       Assert::That(5, Equals(2), "filename", 32);
     }
-    catch(const AssertionException& e)
+    catch (const AssertionException& e)
     {
       line = e.GetLineNumber();
       file = e.GetFilename();

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -7,7 +7,7 @@ void throwRuntimeError() {
 }
 
 struct IgnoreErrors {
-  template <class ExpectedType, class ActualType>
+  template <typename ExpectedType, typename ActualType>
   static void Handle(const ExpectedType&, const ActualType&, const char*, int)
   {
   }

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -10,13 +10,9 @@ void throwRuntimeError()
 struct IgnoreErrors
 {
   template<typename ExpectedType, typename ActualType>
-  static void Handle(const ExpectedType&, const ActualType&, const char*, int)
-  {
-  }
+  static void Handle(const ExpectedType&, const ActualType&, const char*, int) {}
 
-  static void Handle(const std::string&)
-  {
-  }
+  static void Handle(const std::string&) {}
 };
 
 void BasicAssertions()

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -7,7 +7,7 @@ void throwRuntimeError() {
 }
 
 struct IgnoreErrors {
-  template <typename ExpectedType, typename ActualType>
+  template<typename ExpectedType, typename ActualType>
   static void Handle(const ExpectedType&, const ActualType&, const char*, int)
   {
   }

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -3,18 +3,18 @@
 using namespace snowhouse;
 
 void throwRuntimeError() {
-   throw std::runtime_error("This is expected");
+  throw std::runtime_error("This is expected");
 }
 
 struct IgnoreErrors {
-   template <class ExpectedType, class ActualType>
-   static void Handle(const ExpectedType&, const ActualType&, const char*, int)
-   {
-   }
+  template <class ExpectedType, class ActualType>
+  static void Handle(const ExpectedType&, const ActualType&, const char*, int)
+  {
+  }
 
-   static void Handle(const std::string&)
-   {
-   }
+  static void Handle(const std::string&)
+  {
+  }
 };
 
 void BasicAssertions()
@@ -22,56 +22,56 @@ void BasicAssertions()
   describe("Basic assertions");
 
   it("handles integer equality");
-	{
-		AssertThat(5, Is().EqualTo(5));
-	}
+  {
+    AssertThat(5, Is().EqualTo(5));
+  }
 
   it("detects integer inequality");
-	{
-		AssertTestFails(AssertThat(5, Is().EqualTo(4)), "equal to 4");
-	}
+  {
+    AssertTestFails(AssertThat(5, Is().EqualTo(4)), "equal to 4");
+  }
 
   it("detects if Not() fails");
-	{
-		AssertTestFails(AssertThat(5, Is().Not().EqualTo(5)), "Expected: not equal to 5\nActual: 5\n");
-	}
+  {
+    AssertTestFails(AssertThat(5, Is().Not().EqualTo(5)), "Expected: not equal to 5\nActual: 5\n");
+  }
 
   it("handles strings");
-	{
-		AssertThat(std::string("joakim"), Is().EqualTo(std::string("joakim")));
-	}
+  {
+    AssertThat(std::string("joakim"), Is().EqualTo(std::string("joakim")));
+  }
 
   it("handles strings without explicit template specialization");
-	{
-		AssertThat("kim", Is().EqualTo("kim"));
-	}
+  {
+    AssertThat("kim", Is().EqualTo("kim"));
+  }
 
   it("handles GreaterThan()");
-	{
-		AssertThat(5, Is().GreaterThan(4));
-	}
+  {
+    AssertThat(5, Is().GreaterThan(4));
+  }
 
   it("detects when GreaterThan() fails");
-	{
-		AssertTestFails(AssertThat(5, Is().GreaterThan(5)),
+  {
+    AssertTestFails(AssertThat(5, Is().GreaterThan(5)),
         "Expected: greater than 5\nActual: 5\n");
-	}
+  }
 
   it("handles LessThan()");
-	{
-		AssertThat(5, Is().LessThan(6));
-	}
+  {
+    AssertThat(5, Is().LessThan(6));
+  }
 
   it("detects when LessThan() fails");
-	{
-		AssertTestFails(AssertThat(6, Is().LessThan(5)),
+  {
+    AssertTestFails(AssertThat(6, Is().LessThan(5)),
         "Expected: less than 5\nActual: 6\n");
-	}
+  }
 
   it("throws explicit failure message");
-	{
-		AssertTestFails(Assert::Failure("foo"), "foo");
-	}
+  {
+    AssertTestFails(Assert::Failure("foo"), "foo");
+  }
 
   it("contains location information");
   {
@@ -93,129 +93,128 @@ void BasicAssertions()
   }
 
   it("ensures exception is thrown");
-    {
-
-      AssertThrows(std::runtime_error, throwRuntimeError());
-    }
+  {
+    AssertThrows(std::runtime_error, throwRuntimeError());
+  }
 
   it("ignores the error");
-    {
-      ConfigurableAssert<IgnoreErrors>::That(1, Equals(2));
-    }
+  {
+    ConfigurableAssert<IgnoreErrors>::That(1, Equals(2));
+  }
 
   describe("Assertion expression templates");
 
   it("handles integer equality");
-	{
-		AssertThat(5, Equals(5));
-	}
+  {
+    AssertThat(5, Equals(5));
+  }
 
   it("detects integer inequality");
-	{
-		AssertTestFails(AssertThat(5, Equals(4)), "equal to 4");
-	}
+  {
+    AssertTestFails(AssertThat(5, Equals(4)), "equal to 4");
+  }
 
   it("detects if !Equals() fails");
-	{
-		AssertTestFails(AssertThat(5, !Equals(5)),
+  {
+    AssertTestFails(AssertThat(5, !Equals(5)),
         "Expected: not equal to 5\nActual: 5\n");
-	}
+  }
 
   it("handles strings");
-	{
-		AssertThat(std::string("joakim"), Equals(std::string("joakim")));
-	}
+  {
+    AssertThat(std::string("joakim"), Equals(std::string("joakim")));
+  }
 
   it("handles strings without explicit template specialization");
-	{
-		AssertThat("kim", Equals("kim"));
-	}
+  {
+    AssertThat("kim", Equals("kim"));
+  }
 
   it("handles IsGreaterThan()");
-	{
-		AssertThat(5, IsGreaterThan(4));
-	}
+  {
+    AssertThat(5, IsGreaterThan(4));
+  }
 
   it("handles IsGreaterThanOrEqualTo()");
-	{
-		AssertThat(4, IsGreaterThanOrEqualTo(4));
-		AssertThat(5, IsGreaterThanOrEqualTo(4));
-	}
+  {
+    AssertThat(4, IsGreaterThanOrEqualTo(4));
+    AssertThat(5, IsGreaterThanOrEqualTo(4));
+  }
 
   it("detects when IsGreaterThan() fails");
-	{
-		AssertTestFails(AssertThat(5, IsGreaterThan(5)),
+  {
+    AssertTestFails(AssertThat(5, IsGreaterThan(5)),
         "Expected: greater than 5\nActual: 5\n");
-	}
+  }
 
   it("detects when IsGreaterThanOrEqualTo() fails");
-	{
-		AssertTestFails(AssertThat(4, IsGreaterThanOrEqualTo(5)),
+  {
+    AssertTestFails(AssertThat(4, IsGreaterThanOrEqualTo(5)),
         "Expected: greater than or equal to 5\nActual: 4\n");
-	}
+  }
 
   it("handles IsLessThan()");
-	{
-		AssertThat(5, IsLessThan(6));
-	}
+  {
+    AssertThat(5, IsLessThan(6));
+  }
 
   it("handles IsLessThanOrEqualTo()");
-	{
-		AssertThat(5, IsLessThanOrEqualTo(6));
-		AssertThat(6, IsLessThanOrEqualTo(6));
-	}
+  {
+    AssertThat(5, IsLessThanOrEqualTo(6));
+    AssertThat(6, IsLessThanOrEqualTo(6));
+  }
 
   it("detects when IsLessThan() fails");
-	{
-		AssertTestFails(AssertThat(6, IsLessThan(5)),
+  {
+    AssertTestFails(AssertThat(6, IsLessThan(5)),
         "Expected: less than 5\nActual: 6\n");
-	}
+  }
 
   it("detects when IsLessThanOrEqualTo() fails");
-	{
-		AssertTestFails(AssertThat(6, IsLessThanOrEqualTo(5)),
-			"Expected: less than or equal to 5\nActual: 6\n");
-	}
+  {
+    AssertTestFails(AssertThat(6, IsLessThanOrEqualTo(5)),
+        "Expected: less than or equal to 5\nActual: 6\n");
+  }
 
 #ifdef SNOWHOUSE_HAS_NULLPTR
   it("handles IsNull()");
-    {
-       AssertThat(nullptr, IsNull());
-    }
+  {
+    AssertThat(nullptr, IsNull());
+  }
 
   it("handles Is().Null()");
-    {
-       AssertThat(nullptr, Is().Null());
-    }
+  {
+    AssertThat(nullptr, Is().Null());
+  }
 
   it("handles !IsNull()");
-    {
-       int anInt = 0;
-       AssertThat(&anInt, ! IsNull());
-    }
+  {
+    int anInt = 0;
+    AssertThat(&anInt, ! IsNull());
+  }
 
   it("detects when IsNull() fails (real address)");
-    {
-       int anInt = 0;
-       std::ostringstream message;
-       message << "Expected: equal to nullptr\nActual: " << &anInt << "\n";
-       AssertTestFails(AssertThat(&anInt, IsNull()), message.str());
-    }
+  {
+    int anInt = 0;
+    std::ostringstream message;
+    message << "Expected: equal to nullptr\nActual: " << &anInt << "\n";
+    AssertTestFails(AssertThat(&anInt, IsNull()), message.str());
+  }
 
   it("detects when Is().Null() fails");
-    {
-       int anInt = 0;
-       std::ostringstream message;
-       message << "Expected: equal to nullptr\nActual: " << &anInt << "\n";
-       AssertTestFails(AssertThat(&anInt, Is().Null()), message.str());
-    }
+  {
+    int anInt = 0;
+    std::ostringstream message;
+    message << "Expected: equal to nullptr\nActual: " << &anInt << "\n";
+    AssertTestFails(AssertThat(&anInt, Is().Null()), message.str());
+  }
 
   it("detects when !IsNull() fails (nullptr)");
-    {
-       std::ostringstream message;
-       message << "Expected: not equal to nullptr\nActual: nullptr\n";
+  {
+    std::ostringstream message;
+    message << "Expected: not equal to nullptr\nActual: nullptr\n";
 
-       AssertTestFails(AssertThat(nullptr, ! IsNull()), message.str());
-    }
+    AssertTestFails(AssertThat(nullptr, ! IsNull()), message.str());
+  }
 #endif
 }

--- a/example/boolean_operators.cpp
+++ b/example/boolean_operators.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void BooleanOperators()

--- a/example/container_spec.cpp
+++ b/example/container_spec.cpp
@@ -9,8 +9,7 @@ using namespace snowhouse;
 struct my_type
 {
   explicit my_type(int my_val)
-    : my_val_(my_val)
-  {}
+    : my_val_(my_val) {}
 
   friend bool operator==(const my_type&, const my_type&);
   friend bool operator!=(const my_type&, const my_type&);

--- a/example/container_spec.cpp
+++ b/example/container_spec.cpp
@@ -4,6 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include "tests.h"
+
 using namespace snowhouse;
 
 struct my_type

--- a/example/container_spec.cpp
+++ b/example/container_spec.cpp
@@ -9,7 +9,7 @@ using namespace snowhouse;
 struct my_type
 {
   explicit my_type(int my_val)
-    : my_val_(my_val)
+      : my_val_(my_val)
   {
   }
 

--- a/example/container_spec.cpp
+++ b/example/container_spec.cpp
@@ -9,7 +9,9 @@ using namespace snowhouse;
 struct my_type
 {
   explicit my_type(int my_val)
-    : my_val_(my_val) {}
+    : my_val_(my_val)
+  {
+  }
 
   friend bool operator==(const my_type&, const my_type&);
   friend bool operator!=(const my_type&, const my_type&);

--- a/example/custom_matchers_test.cpp
+++ b/example/custom_matchers_test.cpp
@@ -22,11 +22,11 @@ struct IsEvenNumberWithStreamOperator
   }
 
   friend std::ostream& operator<<(std::ostream& stm,
-      const IsEvenNumberWithStreamOperator& );
+      const IsEvenNumberWithStreamOperator&);
 };
 
 std::ostream& operator<<(std::ostream& stm,
-    const IsEvenNumberWithStreamOperator& )
+    const IsEvenNumberWithStreamOperator&)
 {
   stm << "An even number";
   return stm;

--- a/example/custom_matchers_test.cpp
+++ b/example/custom_matchers_test.cpp
@@ -4,6 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include "tests.h"
+
 using namespace snowhouse;
 
 struct IsEvenNumberNoStreamOperator

--- a/example/exceptions_tests.cpp
+++ b/example/exceptions_tests.cpp
@@ -19,7 +19,9 @@ struct ClassWithExceptions
     throw std::range_error("range error!");
   }
 
-  void NoError() {}
+  void NoError()
+  {
+  }
 };
 
 void ExceptionTests()

--- a/example/exceptions_tests.cpp
+++ b/example/exceptions_tests.cpp
@@ -20,9 +20,7 @@ struct ClassWithExceptions
     throw std::range_error("range error!");
   }
 
-  void NoError()
-  {
-  }
+  void NoError() {}
 };
 
 void ExceptionTests()

--- a/example/exceptions_tests.cpp
+++ b/example/exceptions_tests.cpp
@@ -8,9 +8,8 @@
 using namespace snowhouse;
 
 
-class ClassWithExceptions
+struct ClassWithExceptions
 {
-public:
   int LogicError()
   {
     throw std::logic_error("not logical!");

--- a/example/exceptions_tests.cpp
+++ b/example/exceptions_tests.cpp
@@ -4,7 +4,9 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <stdexcept>
+
 #include "tests.h"
+
 using namespace snowhouse;
 
 struct ClassWithExceptions

--- a/example/exceptions_tests.cpp
+++ b/example/exceptions_tests.cpp
@@ -7,7 +7,6 @@
 #include "tests.h"
 using namespace snowhouse;
 
-
 struct ClassWithExceptions
 {
   int LogicError()

--- a/example/expression_error_handling.cpp
+++ b/example/expression_error_handling.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void ExpressionErrorHandling()

--- a/example/expression_error_handling.cpp
+++ b/example/expression_error_handling.cpp
@@ -21,5 +21,4 @@ void ExpressionErrorHandling()
     AssertTestFails(AssertThat(collection, Has().AtLeast(2)),
         "The expression after \"at least 2\" operator does not yield any result");
   }
-
 }

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -31,7 +31,7 @@ int main()
     StringTests();
     StringizeTests();
   }
-  catch(const AssertionException& e)
+  catch (const AssertionException& e)
   {
     std::cout << "Tests failed!" << std::endl;
     std::cout << e.GetMessage() << std::endl;

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -18,18 +18,18 @@ int main()
 {
   try
   {
-  BasicAssertions();
-  BooleanOperators();
-  ContainerConstraints();
-  CustomMatchers();
-  ExceptionTests();
-  ExpressionErrorHandling();
-  MapTests();
-  OperatorTests();
-  SequenceContainerTests();
-  StringLineTests();
-  StringTests();
-  StringizeTests();
+    BasicAssertions();
+    BooleanOperators();
+    ContainerConstraints();
+    CustomMatchers();
+    ExceptionTests();
+    ExpressionErrorHandling();
+    MapTests();
+    OperatorTests();
+    SequenceContainerTests();
+    StringLineTests();
+    StringTests();
+    StringizeTests();
   }
   catch(const AssertionException& e)
   {

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void BooleanOperators();

--- a/example/map_tests.cpp
+++ b/example/map_tests.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void MapTests()

--- a/example/operator_tests.cpp
+++ b/example/operator_tests.cpp
@@ -86,7 +86,7 @@ void OperatorTests()
 
   it("handles both left and right associative operators expression templates");
   {
-    AssertThat(5, IsGreaterThan(4)&& !IsLessThan(3));
+    AssertThat(5, IsGreaterThan(4) && !IsLessThan(3));
   }
 
   it("yields error on malformed expression");

--- a/example/operator_tests.cpp
+++ b/example/operator_tests.cpp
@@ -128,5 +128,4 @@ void OperatorTests()
   {
     AssertThat(2, Is().EqualToWithDelta(1.9, 0.1));
   }
-
 }

--- a/example/operator_tests.cpp
+++ b/example/operator_tests.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void OperatorTests()

--- a/example/sequence_container_tests.cpp
+++ b/example/sequence_container_tests.cpp
@@ -1,7 +1,7 @@
 #include "tests.h"
 using namespace snowhouse;
 
-template <typename T>
+template<typename T>
 void SequenceContainerActual()
 {
   const char* ExpectedActual = "\nActual: [ 1, 2, 3, 5, 8 ]";

--- a/example/sequence_container_tests.cpp
+++ b/example/sequence_container_tests.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 template<typename T>

--- a/example/string_line_tests.cpp
+++ b/example/string_line_tests.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void StringLineTests()

--- a/example/string_tests.cpp
+++ b/example/string_tests.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 void StringTests()

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -1,4 +1,5 @@
 #include "tests.h"
+
 using namespace snowhouse;
 
 namespace

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -1,8 +1,8 @@
 #include "tests.h"
 using namespace snowhouse;
 
-namespace {
-
+namespace
+{
   // No overload for operator<<(std::ostream&) or specialization of snowhouse::Stringizer
   struct WithoutStreamOperator
   {
@@ -38,8 +38,8 @@ namespace {
   };
 }
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<>
   struct Stringizer<WithoutStreamOperatorButWithStringizer>
   {

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -7,7 +7,7 @@ namespace
   struct WithoutStreamOperator
   {
     explicit WithoutStreamOperator(int id)
-      : m_id(id)
+        : m_id(id)
     {
     }
 
@@ -23,7 +23,7 @@ namespace
   struct WithStreamOperator : public WithoutStreamOperator
   {
     explicit WithStreamOperator(int id)
-      : WithoutStreamOperator(id)
+        : WithoutStreamOperator(id)
     {
     }
   };
@@ -38,7 +38,7 @@ namespace
   struct WithoutStreamOperatorButWithStringizer : public WithoutStreamOperator
   {
     explicit WithoutStreamOperatorButWithStringizer(int id)
-      : WithoutStreamOperator(id)
+        : WithoutStreamOperator(id)
     {
     }
   };

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -7,7 +7,7 @@ namespace
   struct WithoutStreamOperator
   {
     explicit WithoutStreamOperator(int id)
-    : m_id(id)
+      : m_id(id)
     {
     }
 
@@ -23,7 +23,7 @@ namespace
   struct WithStreamOperator : public WithoutStreamOperator
   {
     explicit WithStreamOperator(int id)
-    : WithoutStreamOperator(id)
+      : WithoutStreamOperator(id)
     {
     }
   };
@@ -38,7 +38,7 @@ namespace
   struct WithoutStreamOperatorButWithStringizer : public WithoutStreamOperator
   {
     explicit WithoutStreamOperatorButWithStringizer(int id)
-    : WithoutStreamOperator(id)
+      : WithoutStreamOperator(id)
     {
     }
   };

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -7,9 +7,7 @@ namespace
   struct WithoutStreamOperator
   {
     explicit WithoutStreamOperator(int id)
-      : m_id(id)
-    {
-    }
+      : m_id(id) {}
 
     bool operator==(const WithoutStreamOperator& rhs) const
     {
@@ -23,9 +21,7 @@ namespace
   struct WithStreamOperator : public WithoutStreamOperator
   {
     explicit WithStreamOperator(int id)
-      : WithoutStreamOperator(id)
-    {
-    }
+      : WithoutStreamOperator(id) {}
   };
 
   std::ostream& operator<<(std::ostream& stream, const WithStreamOperator& a)
@@ -38,9 +34,7 @@ namespace
   struct WithoutStreamOperatorButWithStringizer : public WithoutStreamOperator
   {
     explicit WithoutStreamOperatorButWithStringizer(int id)
-      : WithoutStreamOperator(id)
-    {
-    }
+      : WithoutStreamOperator(id) {}
   };
 }
 

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -7,7 +7,9 @@ namespace
   struct WithoutStreamOperator
   {
     explicit WithoutStreamOperator(int id)
-      : m_id(id) {}
+      : m_id(id)
+    {
+    }
 
     bool operator==(const WithoutStreamOperator& rhs) const
     {
@@ -21,7 +23,9 @@ namespace
   struct WithStreamOperator : public WithoutStreamOperator
   {
     explicit WithStreamOperator(int id)
-      : WithoutStreamOperator(id) {}
+      : WithoutStreamOperator(id)
+    {
+    }
   };
 
   std::ostream& operator<<(std::ostream& stream, const WithStreamOperator& a)
@@ -34,7 +38,9 @@ namespace
   struct WithoutStreamOperatorButWithStringizer : public WithoutStreamOperator
   {
     explicit WithoutStreamOperatorButWithStringizer(int id)
-      : WithoutStreamOperator(id) {}
+      : WithoutStreamOperator(id)
+    {
+    }
   };
 }
 

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -1,8 +1,8 @@
 #include "tests.h"
 using namespace snowhouse;
 
-namespace
-{
+namespace {
+
   // No overload for operator<<(std::ostream&) or specialization of snowhouse::Stringizer
   struct WithoutStreamOperator
   {

--- a/example/stringize_tests.cpp
+++ b/example/stringize_tests.cpp
@@ -47,7 +47,7 @@ namespace
 namespace snowhouse {
 
   template<>
-  struct Stringizer< WithoutStreamOperatorButWithStringizer >
+  struct Stringizer<WithoutStreamOperatorButWithStringizer>
   {
     static std::string ToString(const WithoutStreamOperatorButWithStringizer& value)
     {

--- a/example/tests.h
+++ b/example/tests.h
@@ -9,7 +9,7 @@
   { \
     assertion; \
   }  \
-  catch(const AssertionException& exception_from_snowhouse_assertion)  \
+  catch (const AssertionException& exception_from_snowhouse_assertion)  \
   {  \
   SNOWHOUSE_INTERNAL_expected_error = exception_from_snowhouse_assertion.GetMessage();  \
   }  \

--- a/example/tests.h
+++ b/example/tests.h
@@ -17,7 +17,8 @@
 
 inline void describe(const char* title)
 {
-  std::cout << std::endl << title << ":" << std::endl;
+  std::cout << std::endl
+            << title << ":" << std::endl;
 }
 
 inline void it(const char* title)

--- a/example/tests.h
+++ b/example/tests.h
@@ -3,6 +3,7 @@
 
 #include <snowhouse/snowhouse.h>
 
+// clang-format off
 #define AssertTestFails(assertion, expected_error_text) \
   std::string SNOWHOUSE_INTERNAL_expected_error = "Test did not fail"; \
   try \
@@ -14,6 +15,7 @@
   SNOWHOUSE_INTERNAL_expected_error = exception_from_snowhouse_assertion.GetMessage();  \
   }  \
   AssertThat(SNOWHOUSE_INTERNAL_expected_error, Is().Containing(expected_error_text));
+// clang-format on
 
 inline void describe(const char* title)
 {

--- a/example/tests.h
+++ b/example/tests.h
@@ -15,12 +15,12 @@
   }  \
   AssertThat(SNOWHOUSE_INTERNAL_expected_error, Is().Containing(expected_error_text));
 
-inline void describe(const char *title)
+inline void describe(const char* title)
 {
   std::cout << std::endl << title << ":" << std::endl;
 }
 
-inline void it(const char *title)
+inline void it(const char* title)
 {
   std::cout << " - " << title << std::endl;
 }

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -110,4 +110,4 @@ namespace snowhouse {
   typedef ConfigurableAssert<DefaultFailureHandler> Assert;
 }
 
-#endif // SNOWHOUSE_ASSERT_H
+#endif

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -20,7 +20,7 @@ namespace snowhouse {
 
   struct DefaultFailureHandler
   {
-    template <typename ExpectedType, typename ActualType>
+    template<typename ExpectedType, typename ActualType>
     static void Handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
     {
       std::ostringstream str;
@@ -40,7 +40,7 @@ namespace snowhouse {
   template<typename FailureHandler>
   struct ConfigurableAssert
   {
-    template <typename ActualType, typename ConstraintListType>
+    template<typename ActualType, typename ConstraintListType>
     static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {
       try
@@ -72,13 +72,13 @@ namespace snowhouse {
       }
     }
 
-    template <typename ConstraintListType>
+    template<typename ConstraintListType>
     static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {
       return That(std::string(actual), expression, file_name, line_number);
     }
 
-    template <typename ActualType, typename ExpressionType>
+    template<typename ActualType, typename ExpressionType>
     static void That(const ActualType& actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
     {
       if (!expression(actual))
@@ -87,7 +87,7 @@ namespace snowhouse {
       }
     }
 
-    template <typename ExpressionType>
+    template<typename ExpressionType>
     static void That(const char* actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
     {
       return That(std::string(actual), expression, file_name, line_number);

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -9,12 +9,14 @@
 #include "assertionexception.h"
 #include "fluent/expressionbuilder.h"
 
+// clang-format off
 #define SNOWHOUSE_ASSERT_THAT(p1, p2, FAILURE_HANDLER) \
   ::snowhouse::ConfigurableAssert<FAILURE_HANDLER>::That((p1), (p2), __FILE__, __LINE__)
 
 #ifndef SNOWHOUSE_NO_MACROS
 # define AssertThat(p1, p2) Assert::That((p1), (p2), __FILE__, __LINE__)
 #endif
+// clang-format on
 
 namespace snowhouse
 {

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -111,4 +111,4 @@ namespace snowhouse {
    typedef ConfigurableAssert<DefaultFailureHandler> Assert;
 }
 
-#endif	// SNOWHOUSE_ASSERT_H
+#endif // SNOWHOUSE_ASSERT_H

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -38,9 +38,8 @@ namespace snowhouse {
   };
 
   template<typename FailureHandler>
-  class ConfigurableAssert
+  struct ConfigurableAssert
   {
-  public:
     template <typename ActualType, typename ConstraintListType>
     static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -18,97 +18,97 @@
 
 namespace snowhouse {
 
-   struct DefaultFailureHandler
-   {
-      template <class ExpectedType, class ActualType>
-      static void Handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
+  struct DefaultFailureHandler
+  {
+    template <class ExpectedType, class ActualType>
+    static void Handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
+    {
+      std::ostringstream str;
+
+      str << "Expected: " << snowhouse::Stringize(expected) << std::endl;
+      str << "Actual: " << snowhouse::Stringize(actual) << std::endl;
+
+      throw AssertionException(str.str(), file_name, line_number);
+    }
+
+    static void Handle(const std::string& message)
+    {
+      throw AssertionException(message);
+    }
+  };
+
+  template<typename FailureHandler>
+  class ConfigurableAssert
+  {
+  public:
+    template <typename ActualType, typename ConstraintListType>
+    static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
+    {
+      try
       {
-         std::ostringstream str;
+        ResultStack result;
+        OperatorStack operators;
+        expression.Evaluate(result, operators, actual);
 
-         str << "Expected: " << snowhouse::Stringize(expected) << std::endl;
-         str << "Actual: " << snowhouse::Stringize(actual) << std::endl;
+        while (!operators.empty())
+        {
+          ConstraintOperator* op = operators.top();
+          op->PerformOperation(result);
+          operators.pop();
+        }
 
-         throw AssertionException(str.str(), file_name, line_number);
+        if (result.empty())
+        {
+          throw InvalidExpressionException("The expression did not yield any result");
+        }
+
+        if (!result.top())
+        {
+          FailureHandler::Handle(expression, actual, file_name, line_number);
+        }
       }
-
-      static void Handle(const std::string& message)
+      catch (const InvalidExpressionException& e)
       {
-         throw AssertionException(message);
+        FailureHandler::Handle("Malformed expression: \"" + snowhouse::Stringize(expression) + "\"\n" + e.Message());
       }
-   };
+    }
 
-   template<typename FailureHandler>
-   class ConfigurableAssert
-   {
-   public:
-      template <typename ActualType, typename ConstraintListType>
-      static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
+    template <typename ConstraintListType>
+    static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
+    {
+      return That(std::string(actual), expression, file_name, line_number);
+    }
+
+    template <typename ActualType, typename ExpressionType>
+    static void That(const ActualType& actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
+    {
+      if (!expression(actual))
       {
-         try
-         {
-            ResultStack result;
-            OperatorStack operators;
-            expression.Evaluate(result, operators, actual);
-
-            while (!operators.empty())
-            {
-               ConstraintOperator* op = operators.top();
-               op->PerformOperation(result);
-               operators.pop();
-            }
-
-            if (result.empty())
-            {
-               throw InvalidExpressionException("The expression did not yield any result");
-            }
-
-            if (!result.top())
-            {
-               FailureHandler::Handle(expression, actual, file_name, line_number);
-            }
-         }
-         catch (const InvalidExpressionException& e)
-         {
-            FailureHandler::Handle("Malformed expression: \"" + snowhouse::Stringize(expression) + "\"\n" + e.Message());
-         }
+        FailureHandler::Handle(expression, actual, file_name, line_number);
       }
+    }
 
-      template <typename ConstraintListType>
-      static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
+    template <typename ExpressionType>
+    static void That(const char* actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
+    {
+      return That(std::string(actual), expression, file_name, line_number);
+    }
+
+    static void That(bool actual)
+    {
+      if (!actual)
       {
-         return That(std::string(actual), expression, file_name, line_number);
+        FailureHandler::Handle("Expected: true\nActual: false");
       }
+    }
 
-      template <typename ActualType, typename ExpressionType>
-      static void That(const ActualType& actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
-      {
-         if (!expression(actual))
-         {
-            FailureHandler::Handle(expression, actual, file_name, line_number);
-         }
-      }
+    static void Failure(const std::string& message)
+    {
+      FailureHandler::Handle(message);
+    }
+  };
 
-      template <typename ExpressionType>
-      static void That(const char* actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
-      {
-         return That(std::string(actual), expression, file_name, line_number);
-      }
-
-      static void That(bool actual)
-      {
-         if (!actual)
-         {
-            FailureHandler::Handle("Expected: true\nActual: false");
-         }
-      }
-
-      static void Failure(const std::string& message)
-      {
-         FailureHandler::Handle(message);
-      }
-   };
-
-   typedef ConfigurableAssert<DefaultFailureHandler> Assert;
+  typedef ConfigurableAssert<DefaultFailureHandler> Assert;
 }
 
 #endif // SNOWHOUSE_ASSERT_H

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -16,8 +16,8 @@
 # define AssertThat(p1, p2) Assert::That((p1), (p2), __FILE__, __LINE__)
 #endif
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct DefaultFailureHandler
   {
     template<typename ExpectedType, typename ActualType>

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -9,11 +9,11 @@
 #include "assertionexception.h"
 #include "fluent/expressionbuilder.h"
 
-#define SNOWHOUSE_ASSERT_THAT(p1,p2,FAILURE_HANDLER) \
+#define SNOWHOUSE_ASSERT_THAT(p1, p2, FAILURE_HANDLER) \
   ::snowhouse::ConfigurableAssert<FAILURE_HANDLER>::That((p1), (p2), __FILE__, __LINE__)
 
 #ifndef SNOWHOUSE_NO_MACROS
-# define AssertThat(p1,p2) Assert::That((p1), (p2), __FILE__, __LINE__)
+# define AssertThat(p1, p2) Assert::That((p1), (p2), __FILE__, __LINE__)
 #endif
 
 namespace snowhouse {

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -20,7 +20,7 @@ namespace snowhouse {
 
   struct DefaultFailureHandler
   {
-    template <class ExpectedType, class ActualType>
+    template <typename ExpectedType, typename ActualType>
     static void Handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
     {
       std::ostringstream str;

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -12,9 +12,8 @@
 #include "macros.h"
 
 namespace snowhouse {
-  class AssertionException : public std::exception
+  struct AssertionException : public std::exception
   {
-  public:
     explicit AssertionException(const std::string& message)
       : m_message(message), m_fileName(""), m_line(0)
     {}

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -11,8 +11,8 @@
 
 #include "macros.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct AssertionException : public std::exception
   {
     explicit AssertionException(const std::string& message)

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -15,25 +15,19 @@ namespace snowhouse {
   struct AssertionException : public std::exception
   {
     explicit AssertionException(const std::string& message)
-      : m_message(message), m_fileName(""), m_line(0)
-    {}
+      : m_message(message), m_fileName(""), m_line(0) {}
 
     AssertionException(const std::string& message, const std::string& fileName, unsigned int line)
-      : m_message(message), m_fileName(fileName), m_line(line)
-    {}
+      : m_message(message), m_fileName(fileName), m_line(line) {}
 
 #if __cplusplus > 199711L
     AssertionException(const AssertionException&) = default;
 #endif
 
 #if __cplusplus > 199711L
-    virtual ~AssertionException() noexcept
-    {
-    }
+    virtual ~AssertionException() noexcept {}
 #else
-    virtual ~AssertionException() throw()
-    {
-    }
+    virtual ~AssertionException() throw() {}
 #endif
 
     std::string GetMessage() const

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -14,48 +14,48 @@
 namespace snowhouse {
   class AssertionException : public std::exception
   {
-    public:
-      explicit AssertionException(const std::string& message)
-        : m_message(message), m_fileName(""), m_line(0)
-      {}
+  public:
+    explicit AssertionException(const std::string& message)
+      : m_message(message), m_fileName(""), m_line(0)
+    {}
 
-      AssertionException(const std::string& message, const std::string& fileName, unsigned int line)
-        : m_message(message), m_fileName(fileName), m_line(line)
-      {}
+    AssertionException(const std::string& message, const std::string& fileName, unsigned int line)
+      : m_message(message), m_fileName(fileName), m_line(line)
+    {}
 
 #if __cplusplus > 199711L
-      AssertionException(const AssertionException&) = default;
+    AssertionException(const AssertionException&) = default;
 #endif
 
 #if __cplusplus > 199711L
-      virtual ~AssertionException() noexcept
-      {
-      }
+    virtual ~AssertionException() noexcept
+    {
+    }
 #else
-      virtual ~AssertionException() throw()
-      {
-      }
+    virtual ~AssertionException() throw()
+    {
+    }
 #endif
 
-      std::string GetMessage() const
-      {
-        return m_message;
-      }
+    std::string GetMessage() const
+    {
+      return m_message;
+    }
 
-      std::string GetFilename() const
-      {
-        return m_fileName;
-      }
+    std::string GetFilename() const
+    {
+      return m_fileName;
+    }
 
-      unsigned int GetLineNumber() const
-      {
-        return m_line;
-      }
+    unsigned int GetLineNumber() const
+    {
+      return m_line;
+    }
 
-    private:
-      std::string m_message;
-      std::string m_fileName;
-      unsigned int m_line;
+  private:
+    std::string m_message;
+    std::string m_fileName;
+    unsigned int m_line;
   };
 }
 

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -53,4 +53,4 @@ namespace snowhouse {
   };
 }
 
-#endif // SNOWHOUSE_ASSERTIONEXCEPTION_H
+#endif

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -16,20 +16,26 @@ namespace snowhouse
   struct AssertionException : public std::exception
   {
     explicit AssertionException(const std::string& message)
-      : m_message(message), m_fileName(""), m_line(0) {}
+      : m_message(message), m_fileName(""), m_line(0)
+    {
+    }
 
     AssertionException(const std::string& message, const std::string& fileName, unsigned int line)
-      : m_message(message), m_fileName(fileName), m_line(line) {}
+      : m_message(message), m_fileName(fileName), m_line(line)
+    {
+    }
 
 #if __cplusplus > 199711L
     AssertionException(const AssertionException&) = default;
 #endif
 
 #if __cplusplus > 199711L
-    virtual ~AssertionException() noexcept {}
+    virtual ~AssertionException() noexcept
 #else
-    virtual ~AssertionException() throw() {}
+    virtual ~AssertionException() throw()
 #endif
+    {
+    }
 
     std::string GetMessage() const
     {

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -16,12 +16,12 @@ namespace snowhouse
   struct AssertionException : public std::exception
   {
     explicit AssertionException(const std::string& message)
-      : m_message(message), m_fileName(""), m_line(0)
+        : m_message(message), m_fileName(""), m_line(0)
     {
     }
 
     AssertionException(const std::string& message, const std::string& fileName, unsigned int line)
-      : m_message(message), m_fileName(fileName), m_line(line)
+        : m_message(message), m_fileName(fileName), m_line(line)
     {
     }
 

--- a/snowhouse/assertionexception.h
+++ b/snowhouse/assertionexception.h
@@ -12,6 +12,7 @@
 #include "macros.h"
 
 namespace snowhouse {
+
   struct AssertionException : public std::exception
   {
     explicit AssertionException(const std::string& message)

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -13,33 +13,33 @@
 
 namespace snowhouse {
 
-  template <typename ContainerType>
+  template<typename ContainerType>
   struct find_in_container_traits
   {
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     static bool find(const ContainerType& container, const ExpectedType& expected)
     {
       return std::find(container.begin(), container.end(), expected) != container.end();
     }
   };
 
-  template <typename KeyType, typename ValueType>
+  template<typename KeyType, typename ValueType>
   struct find_in_container_traits<std::map<KeyType, ValueType> >
   {
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     static bool find(const std::map<KeyType, ValueType>& container, const ExpectedType& expected)
     {
       return container.find(expected) != container.end();
     }
   };
 
-  template <typename ExpectedType>
+  template<typename ExpectedType>
   struct ContainsConstraint : Expression< ContainsConstraint<ExpectedType> >
   {
     ContainsConstraint(const ExpectedType& expected)
       : m_expected(expected) {}
 
-    template <typename ActualType>
+    template<typename ActualType>
     bool operator()(const ActualType& actual) const
     {
       return find_in_container_traits<ActualType>::find(actual, m_expected);
@@ -53,7 +53,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline ContainsConstraint<ExpectedType> Contains(const ExpectedType& expected)
   {
     return ContainsConstraint<ExpectedType>(expected);
@@ -64,7 +64,7 @@ namespace snowhouse {
     return ContainsConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< ContainsConstraint< ExpectedType > >
   {
     static std::string ToString(const ContainsConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -37,7 +37,9 @@ namespace snowhouse
   struct ContainsConstraint : Expression<ContainsConstraint<ExpectedType> >
   {
     ContainsConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -37,7 +37,7 @@ namespace snowhouse
   struct ContainsConstraint : Expression<ContainsConstraint<ExpectedType> >
   {
     ContainsConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -11,8 +11,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ContainerType>
   struct find_in_container_traits
   {

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -34,7 +34,7 @@ namespace snowhouse {
   };
 
   template<typename ExpectedType>
-  struct ContainsConstraint : Expression< ContainsConstraint<ExpectedType> >
+  struct ContainsConstraint : Expression<ContainsConstraint<ExpectedType> >
   {
     ContainsConstraint(const ExpectedType& expected)
       : m_expected(expected) {}
@@ -65,7 +65,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer< ContainsConstraint< ExpectedType > >
+  struct Stringizer<ContainsConstraint<ExpectedType> >
   {
     static std::string ToString(const ContainsConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -37,7 +37,7 @@ namespace snowhouse {
   struct ContainsConstraint : Expression< ContainsConstraint<ExpectedType> >
   {
     ContainsConstraint(const ExpectedType& expected)
-    : m_expected(expected) {}
+      : m_expected(expected) {}
 
     template <typename ActualType>
     bool operator()(const ActualType& actual) const
@@ -70,7 +70,7 @@ namespace snowhouse {
     static std::string ToString(const ContainsConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "contains " << snowhouse::Stringize(constraint.m_expected);
+      builder << "contains " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/containsconstraint.h
+++ b/snowhouse/constraints/containsconstraint.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <map>
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_ENDSWITHCONSTRAINT_H
 #define SNOWHOUSE_ENDSWITHCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct EndsWithConstraint : Expression<EndsWithConstraint<ExpectedType> >
   {
     EndsWithConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     bool operator()(const std::string& actual) const
     {

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct EndsWithConstraint : Expression< EndsWithConstraint<ExpectedType> >
+  struct EndsWithConstraint : Expression<EndsWithConstraint<ExpectedType> >
   {
     EndsWithConstraint(const ExpectedType& expected)
       : m_expected(expected) {}
@@ -37,7 +37,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer< EndsWithConstraint< ExpectedType > >
+  struct Stringizer<EndsWithConstraint<ExpectedType> >
   {
     static std::string ToString(const EndsWithConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template <typename ExpectedType>
+  template<typename ExpectedType>
   struct EndsWithConstraint : Expression< EndsWithConstraint<ExpectedType> >
   {
     EndsWithConstraint(const ExpectedType& expected)
@@ -25,7 +25,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline EndsWithConstraint<ExpectedType> EndsWith(const ExpectedType& expected)
   {
     return EndsWithConstraint<ExpectedType>(expected);
@@ -36,7 +36,7 @@ namespace snowhouse {
     return EndsWithConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< EndsWithConstraint< ExpectedType > >
   {
     static std::string ToString(const EndsWithConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct EndsWithConstraint : Expression<EndsWithConstraint<ExpectedType> >
   {
     EndsWithConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -42,7 +42,7 @@ namespace snowhouse {
     static std::string ToString(const EndsWithConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "ends with " << snowhouse::Stringize(constraint.m_expected);
+      builder << "ends with " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/endswithconstraint.h
+++ b/snowhouse/constraints/endswithconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct EndsWithConstraint : Expression<EndsWithConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct EqualsConstraint : Expression<EqualsConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -70,7 +70,7 @@ namespace snowhouse {
     static std::string ToString(const EqualsConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "equal to " << snowhouse::Stringize(constraint.m_expected);
+      builder << "equal to " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct EqualsConstraint : Expression< EqualsConstraint<ExpectedType> >
   {
     EqualsConstraint(const ExpectedType& expected)
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline EqualsConstraint<ExpectedType> Equals(const ExpectedType& expected)
   {
     return EqualsConstraint<ExpectedType>(expected);
@@ -55,7 +55,7 @@ namespace snowhouse {
   }
 #endif
 
-  template <>
+  template<>
   struct Stringizer< EqualsConstraint< bool > >
   {
     static std::string ToString(const EqualsConstraint<bool>& constraint)
@@ -64,7 +64,7 @@ namespace snowhouse {
     }
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< EqualsConstraint< ExpectedType > >
   {
     static std::string ToString(const EqualsConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct EqualsConstraint : Expression<EqualsConstraint<ExpectedType> >
   {
     EqualsConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct EqualsConstraint : Expression<EqualsConstraint<ExpectedType> >
   {
     EqualsConstraint(const ExpectedType& expected)
-      : m_expected(expected)
-    {
-    }
+      : m_expected(expected) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_EQUALSCONSTRAINT_H
 #define SNOWHOUSE_EQUALSCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct EqualsConstraint : Expression< EqualsConstraint<ExpectedType> >
+  struct EqualsConstraint : Expression<EqualsConstraint<ExpectedType> >
   {
     EqualsConstraint(const ExpectedType& expected)
       : m_expected(expected)
@@ -56,7 +56,7 @@ namespace snowhouse {
 #endif
 
   template<>
-  struct Stringizer< EqualsConstraint< bool > >
+  struct Stringizer<EqualsConstraint<bool> >
   {
     static std::string ToString(const EqualsConstraint<bool>& constraint)
     {
@@ -65,7 +65,7 @@ namespace snowhouse {
   };
 
   template<typename ExpectedType>
-  struct Stringizer< EqualsConstraint< ExpectedType > >
+  struct Stringizer<EqualsConstraint<ExpectedType> >
   {
     static std::string ToString(const EqualsConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct EqualsConstraint : Expression<EqualsConstraint<ExpectedType> >
   {
     EqualsConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -46,10 +46,11 @@ namespace snowhouse {
     const BinaryPredicate predicate_;
 
   private:
-
-#if __cplusplus > 199711L
-#else
-    EqualsContainerConstraint& operator=(const EqualsContainerConstraint&) { return *this; }
+#if __cplusplus <= 199711L
+    EqualsContainerConstraint& operator=(const EqualsContainerConstraint&)
+    {
+      return *this;
+    }
 #endif
 
   };

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_EQUALSCONTAINERCONSTRAINT_H
 #define SNOWHOUSE_EQUALSCONTAINERCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -19,7 +19,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType, typename BinaryPredicate>
-  struct EqualsContainerConstraint : Expression< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
+  struct EqualsContainerConstraint : Expression<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     EqualsContainerConstraint(const ExpectedType& expected, const BinaryPredicate predicate)
       : expected_(expected), predicate_(predicate)
@@ -67,7 +67,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType, typename BinaryPredicate>
-  struct Stringizer< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
+  struct Stringizer<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     static std::string ToString(const EqualsContainerConstraint<ExpectedType, BinaryPredicate>& constraint)
     {

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -18,7 +18,7 @@ namespace snowhouse {
     }
   }
 
-  template< typename ExpectedType, typename BinaryPredicate>
+  template<typename ExpectedType, typename BinaryPredicate>
     struct EqualsContainerConstraint : Expression< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     EqualsContainerConstraint(const ExpectedType& expected, const BinaryPredicate predicate)
@@ -54,19 +54,19 @@ namespace snowhouse {
 
   };
 
-  template< typename ExpectedType>
+  template<typename ExpectedType>
     inline EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)> EqualsContainer(const ExpectedType& expected)
     {
       return EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)>(expected, constraint_internal::default_comparer);
     }
 
-  template< typename ExpectedType, typename BinaryPredicate >
+  template<typename ExpectedType, typename BinaryPredicate>
     inline EqualsContainerConstraint<ExpectedType, BinaryPredicate> EqualsContainer(const ExpectedType& expected, const BinaryPredicate predicate)
     {
       return EqualsContainerConstraint<ExpectedType, BinaryPredicate>(expected, predicate);
     }
 
-  template< typename ExpectedType, typename BinaryPredicate >
+  template<typename ExpectedType, typename BinaryPredicate>
     struct Stringizer< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
     {
       static std::string ToString(const EqualsContainerConstraint<ExpectedType, BinaryPredicate>& constraint)

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -31,9 +31,9 @@ namespace snowhouse {
       typename ActualType::const_iterator actual_it;
       typename ExpectedType::const_iterator expected_it;
 
-      for(actual_it = actual.begin(), expected_it = expected_.begin(); actual_it != actual.end() && expected_it != expected_.end(); ++actual_it, ++expected_it)
+      for (actual_it = actual.begin(), expected_it = expected_.begin(); actual_it != actual.end() && expected_it != expected_.end(); ++actual_it, ++expected_it)
       {
-        if(!predicate_(*actual_it, *expected_it))
+        if (!predicate_(*actual_it, *expected_it))
         {
           return false;
         }

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -19,28 +19,28 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType, typename BinaryPredicate>
-    struct EqualsContainerConstraint : Expression< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
+  struct EqualsContainerConstraint : Expression< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     EqualsContainerConstraint(const ExpectedType& expected, const BinaryPredicate predicate)
       : expected_(expected), predicate_(predicate)
     {}
 
     template<typename ActualType>
-      bool operator()(const ActualType& actual) const
+    bool operator()(const ActualType& actual) const
+    {
+      typename ActualType::const_iterator actual_it;
+      typename ExpectedType::const_iterator expected_it;
+
+      for(actual_it = actual.begin(), expected_it = expected_.begin(); actual_it != actual.end() && expected_it != expected_.end(); ++actual_it, ++expected_it)
       {
-        typename ActualType::const_iterator actual_it;
-        typename ExpectedType::const_iterator expected_it;
-
-        for(actual_it = actual.begin(), expected_it = expected_.begin(); actual_it != actual.end() && expected_it != expected_.end(); ++actual_it, ++expected_it)
+        if(!predicate_(*actual_it, *expected_it))
         {
-          if(!predicate_(*actual_it, *expected_it))
-          {
-            return false;
-          }
+          return false;
         }
-
-        return actual.size() == expected_.size();
       }
+
+      return actual.size() == expected_.size();
+    }
 
     const ExpectedType expected_;
     const BinaryPredicate predicate_;
@@ -55,27 +55,27 @@ namespace snowhouse {
   };
 
   template<typename ExpectedType>
-    inline EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)> EqualsContainer(const ExpectedType& expected)
-    {
-      return EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)>(expected, constraint_internal::default_comparer);
-    }
+  inline EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)> EqualsContainer(const ExpectedType& expected)
+  {
+    return EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)>(expected, constraint_internal::default_comparer);
+  }
 
   template<typename ExpectedType, typename BinaryPredicate>
-    inline EqualsContainerConstraint<ExpectedType, BinaryPredicate> EqualsContainer(const ExpectedType& expected, const BinaryPredicate predicate)
-    {
-      return EqualsContainerConstraint<ExpectedType, BinaryPredicate>(expected, predicate);
-    }
+  inline EqualsContainerConstraint<ExpectedType, BinaryPredicate> EqualsContainer(const ExpectedType& expected, const BinaryPredicate predicate)
+  {
+    return EqualsContainerConstraint<ExpectedType, BinaryPredicate>(expected, predicate);
+  }
 
   template<typename ExpectedType, typename BinaryPredicate>
-    struct Stringizer< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
+  struct Stringizer< EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
+  {
+    static std::string ToString(const EqualsContainerConstraint<ExpectedType, BinaryPredicate>& constraint)
     {
-      static std::string ToString(const EqualsContainerConstraint<ExpectedType, BinaryPredicate>& constraint)
-      {
-        std::ostringstream builder;
-        builder << snowhouse::Stringize(constraint.expected_);
-        return builder.str();
-      }
-    };
+      std::ostringstream builder;
+      builder << snowhouse::Stringize(constraint.expected_);
+      return builder.str();
+    }
+  };
 }
 
 #endif

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -23,7 +23,9 @@ namespace snowhouse
   struct EqualsContainerConstraint : Expression<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     EqualsContainerConstraint(const ExpectedType& expected, const BinaryPredicate predicate)
-      : expected_(expected), predicate_(predicate) {}
+      : expected_(expected), predicate_(predicate)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -23,7 +23,7 @@ namespace snowhouse
   struct EqualsContainerConstraint : Expression<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     EqualsContainerConstraint(const ExpectedType& expected, const BinaryPredicate predicate)
-      : expected_(expected), predicate_(predicate)
+        : expected_(expected), predicate_(predicate)
     {
     }
 

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -22,8 +22,7 @@ namespace snowhouse {
   struct EqualsContainerConstraint : Expression<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >
   {
     EqualsContainerConstraint(const ExpectedType& expected, const BinaryPredicate predicate)
-      : expected_(expected), predicate_(predicate)
-    {}
+      : expected_(expected), predicate_(predicate) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -11,6 +11,7 @@
 namespace snowhouse {
 
   namespace constraint_internal {
+
     template<typename T>
     inline bool default_comparer(const T& lhs, const T& rhs)
     {

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -8,10 +8,10 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
-  namespace constraint_internal {
-
+namespace snowhouse
+{
+  namespace constraint_internal
+  {
     template<typename T>
     inline bool default_comparer(const T& lhs, const T& rhs)
     {

--- a/snowhouse/constraints/equalscontainerconstraint.h
+++ b/snowhouse/constraints/equalscontainerconstraint.h
@@ -52,7 +52,6 @@ namespace snowhouse {
       return *this;
     }
 #endif
-
   };
 
   template<typename ExpectedType>

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -40,7 +40,7 @@ namespace snowhouse {
     static std::string ToString(const EqualsWithDeltaConstraint<ExpectedType, DeltaType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "equal to " << snowhouse::Stringize(constraint.m_expected) << " (+/- " << snowhouse::Stringize(constraint.m_delta) << ")";
+      builder << "equal to " << snowhouse::Stringize(constraint.m_expected) << " (+/- " << snowhouse::Stringize(constraint.m_delta) << ")";
 
       return builder.str();
     }

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpectedType, typename DeltaType >
+  template<typename ExpectedType, typename DeltaType>
   struct EqualsWithDeltaConstraint : Expression< EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {
     EqualsWithDeltaConstraint(const ExpectedType& expected, const DeltaType& delta)
@@ -28,13 +28,13 @@ namespace snowhouse {
     DeltaType m_delta;
   };
 
-  template< typename ExpectedType, typename DeltaType >
+  template<typename ExpectedType, typename DeltaType>
   inline EqualsWithDeltaConstraint<ExpectedType, DeltaType> EqualsWithDelta(const ExpectedType& expected, const DeltaType& delta)
   {
     return EqualsWithDeltaConstraint<ExpectedType, DeltaType>(expected, delta);
   }
 
-  template< typename ExpectedType, typename DeltaType >
+  template<typename ExpectedType, typename DeltaType>
   struct Stringizer< EqualsWithDeltaConstraint< ExpectedType, DeltaType > >
   {
     static std::string ToString(const EqualsWithDeltaConstraint<ExpectedType, DeltaType>& constraint)

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType, typename DeltaType>
   struct EqualsWithDeltaConstraint : Expression<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct EqualsWithDeltaConstraint : Expression<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {
     EqualsWithDeltaConstraint(const ExpectedType& expected, const DeltaType& delta)
-      : m_expected(expected), m_delta(delta) {}
+      : m_expected(expected), m_delta(delta)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_EQUALSWITHDELTACONSTRAINT_H
 #define SNOWHOUSE_EQUALSWITHDELTACONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct EqualsWithDeltaConstraint : Expression<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {
     EqualsWithDeltaConstraint(const ExpectedType& expected, const DeltaType& delta)
-      : m_expected(expected), m_delta(delta)
-    {
-    }
+      : m_expected(expected), m_delta(delta) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct EqualsWithDeltaConstraint : Expression<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {
     EqualsWithDeltaConstraint(const ExpectedType& expected, const DeltaType& delta)
-      : m_expected(expected), m_delta(delta)
+        : m_expected(expected), m_delta(delta)
     {
     }
 

--- a/snowhouse/constraints/equalswithdeltaconstraint.h
+++ b/snowhouse/constraints/equalswithdeltaconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType, typename DeltaType>
-  struct EqualsWithDeltaConstraint : Expression< EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
+  struct EqualsWithDeltaConstraint : Expression<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {
     EqualsWithDeltaConstraint(const ExpectedType& expected, const DeltaType& delta)
       : m_expected(expected), m_delta(delta)
@@ -35,7 +35,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType, typename DeltaType>
-  struct Stringizer< EqualsWithDeltaConstraint< ExpectedType, DeltaType > >
+  struct Stringizer<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >
   {
     static std::string ToString(const EqualsWithDeltaConstraint<ExpectedType, DeltaType>& constraint)
     {

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -15,7 +15,7 @@ namespace snowhouse
   struct AndExpression : Expression<AndExpression<LeftExpression, RightExpression> >
   {
     AndExpression(const LeftExpression& left, const RightExpression& right)
-      : m_left(left), m_right(right)
+        : m_left(left), m_right(right)
     {
     }
 

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -7,7 +7,7 @@
 #define SNOWHOUSE_ANDEXPRESSION_H
 
 #include "../../stringize.h"
-#include "./expression_fwd.h"
+#include "expression_fwd.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -12,7 +12,7 @@
 namespace snowhouse {
 
   template<typename LeftExpression, typename RightExpression>
-  struct AndExpression : Expression< AndExpression<LeftExpression, RightExpression> >
+  struct AndExpression : Expression<AndExpression<LeftExpression, RightExpression> >
   {
     AndExpression(const LeftExpression& left, const RightExpression& right)
       : m_left(left)
@@ -31,7 +31,7 @@ namespace snowhouse {
   };
 
   template<typename LeftExpression, typename RightExpression>
-  struct Stringizer< AndExpression<LeftExpression, RightExpression> >
+  struct Stringizer<AndExpression<LeftExpression, RightExpression> >
   {
     static std::string ToString(const AndExpression<LeftExpression, RightExpression>& expression)
     {

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -9,8 +9,8 @@
 #include "../../stringize.h"
 #include "./expression_fwd.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename LeftExpression, typename RightExpression>
   struct AndExpression : Expression<AndExpression<LeftExpression, RightExpression> >
   {

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -11,7 +11,7 @@
 
 namespace snowhouse {
 
-  template< typename LeftExpression, typename RightExpression >
+  template<typename LeftExpression, typename RightExpression>
   struct AndExpression : Expression< AndExpression<LeftExpression, RightExpression> >
   {
     AndExpression(const LeftExpression& left, const RightExpression& right)
@@ -20,7 +20,7 @@ namespace snowhouse {
     {
     }
 
-    template< typename ActualType >
+    template<typename ActualType>
     bool operator()(const ActualType& actual) const
     {
       return (m_left(actual) && m_right(actual));
@@ -30,7 +30,7 @@ namespace snowhouse {
     RightExpression m_right;
   };
 
-  template< typename LeftExpression, typename RightExpression >
+  template<typename LeftExpression, typename RightExpression>
   struct Stringizer< AndExpression<LeftExpression, RightExpression> >
   {
     static std::string ToString(const AndExpression<LeftExpression, RightExpression>& expression)

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -15,7 +15,9 @@ namespace snowhouse
   struct AndExpression : Expression<AndExpression<LeftExpression, RightExpression> >
   {
     AndExpression(const LeftExpression& left, const RightExpression& right)
-      : m_left(left), m_right(right) {}
+      : m_left(left), m_right(right)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/expressions/andexpression.h
+++ b/snowhouse/constraints/expressions/andexpression.h
@@ -15,10 +15,7 @@ namespace snowhouse {
   struct AndExpression : Expression<AndExpression<LeftExpression, RightExpression> >
   {
     AndExpression(const LeftExpression& left, const RightExpression& right)
-      : m_left(left)
-      , m_right(right)
-    {
-    }
+      : m_left(left), m_right(right) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/expressions/expression.h
+++ b/snowhouse/constraints/expressions/expression.h
@@ -10,8 +10,8 @@
 #include "./andexpression.h"
 #include "./orexpression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename T>
   struct Expression
   {

--- a/snowhouse/constraints/expressions/expression.h
+++ b/snowhouse/constraints/expressions/expression.h
@@ -20,13 +20,13 @@ namespace snowhouse {
       return NotExpression<T>(static_cast<const T&>(*this));
     }
 
-    template< typename Right >
+    template<typename Right>
     AndExpression<T, Right> operator&&(const Right& right) const
     {
       return AndExpression<T, Right>(static_cast<const T&>(*this), right);
     }
 
-    template< typename Right >
+    template<typename Right>
     OrExpression<T, Right> operator||(const Right& right) const
     {
       return OrExpression<T, Right>(static_cast<const T&>(*this), right);

--- a/snowhouse/constraints/expressions/expression.h
+++ b/snowhouse/constraints/expressions/expression.h
@@ -6,9 +6,9 @@
 #ifndef SNOWHOUSE_EXPRESSION_H
 #define SNOWHOUSE_EXPRESSION_H
 
-#include "./notexpression.h"
-#include "./andexpression.h"
-#include "./orexpression.h"
+#include "notexpression.h"
+#include "andexpression.h"
+#include "orexpression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/expressions/expression_fwd.h
+++ b/snowhouse/constraints/expressions/expression_fwd.h
@@ -7,6 +7,7 @@
 #define SNOWHOUSE_EXPRESSION_FWD_H
 
 namespace snowhouse {
+
   template<typename T>
   struct Expression;
 }

--- a/snowhouse/constraints/expressions/expression_fwd.h
+++ b/snowhouse/constraints/expressions/expression_fwd.h
@@ -7,8 +7,8 @@
 #define SNOWHOUSE_EXPRESSION_FWD_H
 
 namespace snowhouse {
-	template<typename T>
-	struct Expression;
+  template<typename T>
+  struct Expression;
 }
 
 #endif

--- a/snowhouse/constraints/expressions/expression_fwd.h
+++ b/snowhouse/constraints/expressions/expression_fwd.h
@@ -6,8 +6,8 @@
 #ifndef SNOWHOUSE_EXPRESSION_FWD_H
 #define SNOWHOUSE_EXPRESSION_FWD_H
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename T>
   struct Expression;
 }

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -12,7 +12,7 @@
 namespace snowhouse {
 
   template<typename ExpressionType>
-  struct NotExpression : Expression< NotExpression<ExpressionType> >
+  struct NotExpression : Expression<NotExpression<ExpressionType> >
   {
     explicit NotExpression(const ExpressionType& expression)
       : m_expression(expression)
@@ -29,7 +29,7 @@ namespace snowhouse {
   };
 
   template<typename ExpressionType>
-  struct Stringizer< NotExpression<ExpressionType> >
+  struct Stringizer<NotExpression<ExpressionType> >
   {
     static std::string ToString(const NotExpression<ExpressionType>& expression)
     {

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -15,9 +15,7 @@ namespace snowhouse {
   struct NotExpression : Expression<NotExpression<ExpressionType> >
   {
     explicit NotExpression(const ExpressionType& expression)
-      : m_expression(expression)
-    {
-    }
+      : m_expression(expression) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -15,7 +15,9 @@ namespace snowhouse
   struct NotExpression : Expression<NotExpression<ExpressionType> >
   {
     explicit NotExpression(const ExpressionType& expression)
-      : m_expression(expression) {}
+      : m_expression(expression)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -7,7 +7,7 @@
 #define SNOWHOUSE_NOTEXPRESSION_H
 
 #include "../../stringize.h"
-#include "./expression_fwd.h"
+#include "expression_fwd.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -11,7 +11,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpressionType >
+  template<typename ExpressionType>
   struct NotExpression : Expression< NotExpression<ExpressionType> >
   {
     explicit NotExpression(const ExpressionType& expression)
@@ -28,7 +28,7 @@ namespace snowhouse {
     ExpressionType m_expression;
   };
 
-  template< typename ExpressionType >
+  template<typename ExpressionType>
   struct Stringizer< NotExpression<ExpressionType> >
   {
     static std::string ToString(const NotExpression<ExpressionType>& expression)

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -9,8 +9,8 @@
 #include "../../stringize.h"
 #include "./expression_fwd.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpressionType>
   struct NotExpression : Expression<NotExpression<ExpressionType> >
   {

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -34,7 +34,7 @@ namespace snowhouse {
     static std::string ToString(const NotExpression<ExpressionType>& expression)
     {
       std::ostringstream builder;
-	  builder << "not " << snowhouse::Stringize(expression.m_expression);
+      builder << "not " << snowhouse::Stringize(expression.m_expression);
 
       return builder.str();
     }

--- a/snowhouse/constraints/expressions/notexpression.h
+++ b/snowhouse/constraints/expressions/notexpression.h
@@ -15,7 +15,7 @@ namespace snowhouse
   struct NotExpression : Expression<NotExpression<ExpressionType> >
   {
     explicit NotExpression(const ExpressionType& expression)
-      : m_expression(expression)
+        : m_expression(expression)
     {
     }
 

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -11,7 +11,7 @@
 
 namespace snowhouse {
 
-  template< typename LeftExpression, typename RightExpression >
+  template<typename LeftExpression, typename RightExpression>
   struct OrExpression : Expression< OrExpression<LeftExpression, RightExpression> >
   {
     OrExpression(const LeftExpression& left, const RightExpression& right)
@@ -20,7 +20,7 @@ namespace snowhouse {
     {
     }
 
-    template< typename ActualType >
+    template<typename ActualType>
     bool operator()(const ActualType& actual) const
     {
       return (m_left(actual) || m_right(actual));
@@ -30,7 +30,7 @@ namespace snowhouse {
     RightExpression m_right;
   };
 
-  template< typename LeftExpression, typename RightExpression >
+  template<typename LeftExpression, typename RightExpression>
   struct Stringizer< OrExpression<LeftExpression, RightExpression> >
   {
     static std::string ToString(const OrExpression<LeftExpression, RightExpression>& expression)

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -12,7 +12,7 @@
 namespace snowhouse {
 
   template<typename LeftExpression, typename RightExpression>
-  struct OrExpression : Expression< OrExpression<LeftExpression, RightExpression> >
+  struct OrExpression : Expression<OrExpression<LeftExpression, RightExpression> >
   {
     OrExpression(const LeftExpression& left, const RightExpression& right)
       : m_left(left)
@@ -31,7 +31,7 @@ namespace snowhouse {
   };
 
   template<typename LeftExpression, typename RightExpression>
-  struct Stringizer< OrExpression<LeftExpression, RightExpression> >
+  struct Stringizer<OrExpression<LeftExpression, RightExpression> >
   {
     static std::string ToString(const OrExpression<LeftExpression, RightExpression>& expression)
     {

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -36,7 +36,7 @@ namespace snowhouse {
     static std::string ToString(const OrExpression<LeftExpression, RightExpression>& expression)
     {
       std::ostringstream builder;
-	  builder << snowhouse::Stringize(expression.m_left) << " or " << snowhouse::Stringize(expression.m_right);
+      builder << snowhouse::Stringize(expression.m_left) << " or " << snowhouse::Stringize(expression.m_right);
 
       return builder.str();
     }

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -15,7 +15,9 @@ namespace snowhouse
   struct OrExpression : Expression<OrExpression<LeftExpression, RightExpression> >
   {
     OrExpression(const LeftExpression& left, const RightExpression& right)
-      : m_left(left), m_right(right) {}
+      : m_left(left), m_right(right)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -15,7 +15,7 @@ namespace snowhouse
   struct OrExpression : Expression<OrExpression<LeftExpression, RightExpression> >
   {
     OrExpression(const LeftExpression& left, const RightExpression& right)
-      : m_left(left), m_right(right)
+        : m_left(left), m_right(right)
     {
     }
 

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -15,10 +15,7 @@ namespace snowhouse {
   struct OrExpression : Expression<OrExpression<LeftExpression, RightExpression> >
   {
     OrExpression(const LeftExpression& left, const RightExpression& right)
-      : m_left(left)
-      , m_right(right)
-    {
-    }
+      : m_left(left), m_right(right) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -7,7 +7,7 @@
 #define SNOWHOUSE_OREXPRESSION_H
 
 #include "../../stringize.h"
-#include "./expression_fwd.h"
+#include "expression_fwd.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/expressions/orexpression.h
+++ b/snowhouse/constraints/expressions/orexpression.h
@@ -9,8 +9,8 @@
 #include "../../stringize.h"
 #include "./expression_fwd.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename LeftExpression, typename RightExpression>
   struct OrExpression : Expression<OrExpression<LeftExpression, RightExpression> >
   {

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct FulfillsConstraint : Expression<FulfillsConstraint<MatcherType> >
   {
     FulfillsConstraint(const MatcherType& matcher)
-      : m_matcher(matcher)
-    {
-    }
+      : m_matcher(matcher) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename MatcherType >
+  template<typename MatcherType>
   struct FulfillsConstraint : Expression< FulfillsConstraint<MatcherType> >
   {
     FulfillsConstraint(const MatcherType& matcher)
@@ -27,13 +27,13 @@ namespace snowhouse {
     MatcherType m_matcher;
   };
 
-  template< typename MatcherType >
+  template<typename MatcherType>
   inline FulfillsConstraint<MatcherType> Fulfills(const MatcherType& matcher)
   {
     return FulfillsConstraint<MatcherType>(matcher);
   }
 
-  template< typename MatcherType >
+  template<typename MatcherType>
   struct Stringizer< FulfillsConstraint< MatcherType > >
   {
     static std::string ToString(const FulfillsConstraint<MatcherType>& constraint)

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct FulfillsConstraint : Expression<FulfillsConstraint<MatcherType> >
   {
     FulfillsConstraint(const MatcherType& matcher)
-      : m_matcher(matcher) {}
+      : m_matcher(matcher)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename MatcherType>
-  struct FulfillsConstraint : Expression< FulfillsConstraint<MatcherType> >
+  struct FulfillsConstraint : Expression<FulfillsConstraint<MatcherType> >
   {
     FulfillsConstraint(const MatcherType& matcher)
       : m_matcher(matcher)
@@ -34,7 +34,7 @@ namespace snowhouse {
   }
 
   template<typename MatcherType>
-  struct Stringizer< FulfillsConstraint< MatcherType > >
+  struct Stringizer<FulfillsConstraint<MatcherType> >
   {
     static std::string ToString(const FulfillsConstraint<MatcherType>& constraint)
     {

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_FULFILLSCONSTRAINT_H
 #define SNOWHOUSE_FULFILLSCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -3,8 +3,8 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef FULFILLSCONSTRAINT_H
-#define FULFILLSCONSTRAINT_H
+#ifndef SNOWHOUSE_FULFILLSCONSTRAINT_H
+#define SNOWHOUSE_FULFILLSCONSTRAINT_H
 
 #include "./expressions/expression.h"
 

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -42,7 +42,6 @@ namespace snowhouse {
       return builder.str();
     }
   };
-
 }
 
 #endif

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct FulfillsConstraint : Expression<FulfillsConstraint<MatcherType> >
   {
     FulfillsConstraint(const MatcherType& matcher)
-      : m_matcher(matcher)
+        : m_matcher(matcher)
     {
     }
 

--- a/snowhouse/constraints/fulfillsconstraint.h
+++ b/snowhouse/constraints/fulfillsconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename MatcherType>
   struct FulfillsConstraint : Expression<FulfillsConstraint<MatcherType> >
   {

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct HasLengthConstraint : Expression< HasLengthConstraint<ExpectedType> >
+  struct HasLengthConstraint : Expression<HasLengthConstraint<ExpectedType> >
   {
     HasLengthConstraint(const ExpectedType& expected)
       : m_expected(expected) {}
@@ -44,7 +44,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer< HasLengthConstraint< ExpectedType > >
+  struct Stringizer<HasLengthConstraint<ExpectedType> >
   {
     static std::string ToString(const HasLengthConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -49,7 +49,7 @@ namespace snowhouse {
     static std::string ToString(const HasLengthConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "of length " << snowhouse::Stringize(constraint.m_expected);
+      builder << "of length " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_HASLENGTHCONSTRAINT_H
 #define SNOWHOUSE_HASLENGTHCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -10,13 +10,13 @@
 
 namespace snowhouse {
 
-  template <typename ExpectedType>
+  template<typename ExpectedType>
   struct HasLengthConstraint : Expression< HasLengthConstraint<ExpectedType> >
   {
     HasLengthConstraint(const ExpectedType& expected)
       : m_expected(expected) {}
 
-    template <typename ActualType>
+    template<typename ActualType>
     bool operator()(const ActualType& actual) const
     {
       typedef typename ActualType::size_type SizeType;
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline HasLengthConstraint<ExpectedType> HasLength(const ExpectedType& expected)
   {
     return HasLengthConstraint<ExpectedType>(expected);
@@ -43,7 +43,7 @@ namespace snowhouse {
     return HasLengthConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< HasLengthConstraint< ExpectedType > >
   {
     static std::string ToString(const HasLengthConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct HasLengthConstraint : Expression<HasLengthConstraint<ExpectedType> >
   {
     HasLengthConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct HasLengthConstraint : Expression<HasLengthConstraint<ExpectedType> >
   {
     HasLengthConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/haslengthconstraint.h
+++ b/snowhouse/constraints/haslengthconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct HasLengthConstraint : Expression<HasLengthConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct IsGreaterThanConstraint : Expression< IsGreaterThanConstraint<ExpectedType> >
   {
     IsGreaterThanConstraint(const ExpectedType& expected)
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline IsGreaterThanConstraint<ExpectedType> IsGreaterThan(const ExpectedType& expected)
   {
     return IsGreaterThanConstraint<ExpectedType>(expected);
@@ -38,7 +38,7 @@ namespace snowhouse {
     return IsGreaterThanConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< IsGreaterThanConstraint< ExpectedType > >
   {
     static std::string ToString(const IsGreaterThanConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -44,7 +44,7 @@ namespace snowhouse {
     static std::string ToString(const IsGreaterThanConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "greater than " << snowhouse::Stringize(constraint.m_expected);
+      builder << "greater than " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct IsGreaterThanConstraint : Expression<IsGreaterThanConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct IsGreaterThanConstraint : Expression<IsGreaterThanConstraint<ExpectedType> >
   {
     IsGreaterThanConstraint(const ExpectedType& expected)
-      : m_expected(expected)
-    {
-    }
+      : m_expected(expected) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct IsGreaterThanConstraint : Expression<IsGreaterThanConstraint<ExpectedType> >
   {
     IsGreaterThanConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct IsGreaterThanConstraint : Expression< IsGreaterThanConstraint<ExpectedType> >
+  struct IsGreaterThanConstraint : Expression<IsGreaterThanConstraint<ExpectedType> >
   {
     IsGreaterThanConstraint(const ExpectedType& expected)
       : m_expected(expected)
@@ -39,7 +39,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer< IsGreaterThanConstraint< ExpectedType > >
+  struct Stringizer<IsGreaterThanConstraint<ExpectedType> >
   {
     static std::string ToString(const IsGreaterThanConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct IsGreaterThanConstraint : Expression<IsGreaterThanConstraint<ExpectedType> >
   {
     IsGreaterThanConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/isgreaterthanconstraint.h
+++ b/snowhouse/constraints/isgreaterthanconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_ISGREATERTHANCONSTRAINT_H
 #define SNOWHOUSE_ISGREATERTHANCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct IsGreaterThanOrEqualToConstraint : Expression<IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct IsGreaterThanOrEqualToConstraint : Expression < IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {
     IsGreaterThanOrEqualToConstraint(const ExpectedType& expected)
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline IsGreaterThanOrEqualToConstraint<ExpectedType> IsGreaterThanOrEqualTo(const ExpectedType& expected)
   {
     return IsGreaterThanOrEqualToConstraint<ExpectedType>(expected);
@@ -38,7 +38,7 @@ namespace snowhouse {
     return IsGreaterThanOrEqualToConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer < IsGreaterThanOrEqualToConstraint< ExpectedType > >
   {
     static std::string ToString(const IsGreaterThanOrEqualToConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_ISGREATERTHANOREQUALTOCONSTRAINT_H
 #define SNOWHOUSE_ISGREATERTHANOREQUALTOCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct IsGreaterThanOrEqualToConstraint : Expression < IsGreaterThanOrEqualToConstraint<ExpectedType> >
+  struct IsGreaterThanOrEqualToConstraint : Expression<IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {
     IsGreaterThanOrEqualToConstraint(const ExpectedType& expected)
       : m_expected(expected)
@@ -39,7 +39,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer < IsGreaterThanOrEqualToConstraint< ExpectedType > >
+  struct Stringizer<IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {
     static std::string ToString(const IsGreaterThanOrEqualToConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct IsGreaterThanOrEqualToConstraint : Expression<IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {
     IsGreaterThanOrEqualToConstraint(const ExpectedType& expected)
-      : m_expected(expected)
-    {
-    }
+      : m_expected(expected) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct IsGreaterThanOrEqualToConstraint : Expression<IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {
     IsGreaterThanOrEqualToConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct IsGreaterThanOrEqualToConstraint : Expression<IsGreaterThanOrEqualToConstraint<ExpectedType> >
   {
     IsGreaterThanOrEqualToConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_ISLESSTHANCONSTRAINT_H
 #define SNOWHOUSE_ISLESSTHANCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct IsLessThanConstraint : Expression< IsLessThanConstraint<ExpectedType> >
+  struct IsLessThanConstraint : Expression<IsLessThanConstraint<ExpectedType> >
   {
     IsLessThanConstraint(const ExpectedType& expected)
       : m_expected(expected)
@@ -39,7 +39,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer< IsLessThanConstraint< ExpectedType > >
+  struct Stringizer<IsLessThanConstraint<ExpectedType> >
   {
     static std::string ToString(const IsLessThanConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct IsLessThanConstraint : Expression<IsLessThanConstraint<ExpectedType> >
   {
     IsLessThanConstraint(const ExpectedType& expected)
-      : m_expected(expected)
-    {
-    }
+      : m_expected(expected) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct IsLessThanConstraint : Expression<IsLessThanConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct IsLessThanConstraint : Expression< IsLessThanConstraint<ExpectedType> >
   {
     IsLessThanConstraint(const ExpectedType& expected)
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline IsLessThanConstraint<ExpectedType> IsLessThan(const ExpectedType& expected)
   {
     return IsLessThanConstraint<ExpectedType>(expected);
@@ -38,7 +38,7 @@ namespace snowhouse {
     return IsLessThanConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< IsLessThanConstraint< ExpectedType > >
   {
     static std::string ToString(const IsLessThanConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -44,7 +44,7 @@ namespace snowhouse {
     static std::string ToString(const IsLessThanConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "less than " << snowhouse::Stringize(constraint.m_expected);
+      builder << "less than " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct IsLessThanConstraint : Expression<IsLessThanConstraint<ExpectedType> >
   {
     IsLessThanConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/islessthanconstraint.h
+++ b/snowhouse/constraints/islessthanconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct IsLessThanConstraint : Expression<IsLessThanConstraint<ExpectedType> >
   {
     IsLessThanConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct IsLessThanOrEqualToConstraint : Expression<IsLessThanOrEqualToConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct IsLessThanOrEqualToConstraint : Expression<IsLessThanOrEqualToConstraint<ExpectedType> >
   {
     IsLessThanOrEqualToConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_ISLESSTHANOREQUALTOCONSTRAINT_H
 #define SNOWHOUSE_ISLESSTHANOREQUALTOCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -14,9 +14,7 @@ namespace snowhouse {
   struct IsLessThanOrEqualToConstraint : Expression<IsLessThanOrEqualToConstraint<ExpectedType> >
   {
     IsLessThanOrEqualToConstraint(const ExpectedType& expected)
-      : m_expected(expected)
-    {
-    }
+      : m_expected(expected) {}
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct IsLessThanOrEqualToConstraint : Expression<IsLessThanOrEqualToConstraint<ExpectedType> >
   {
     IsLessThanOrEqualToConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     template<typename ActualType>
     bool operator()(const ActualType& actual) const

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct IsLessThanOrEqualToConstraint : Expression < IsLessThanOrEqualToConstraint<ExpectedType> >
+  struct IsLessThanOrEqualToConstraint : Expression<IsLessThanOrEqualToConstraint<ExpectedType> >
   {
     IsLessThanOrEqualToConstraint(const ExpectedType& expected)
       : m_expected(expected)
@@ -39,7 +39,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer < IsLessThanOrEqualToConstraint< ExpectedType > >
+  struct Stringizer<IsLessThanOrEqualToConstraint<ExpectedType> >
   {
     static std::string ToString(const IsLessThanOrEqualToConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct IsLessThanOrEqualToConstraint : Expression < IsLessThanOrEqualToConstraint<ExpectedType> >
   {
     IsLessThanOrEqualToConstraint(const ExpectedType& expected)
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline IsLessThanOrEqualToConstraint<ExpectedType> IsLessThanOrEqualTo(const ExpectedType& expected)
   {
     return IsLessThanOrEqualToConstraint<ExpectedType>(expected);
@@ -38,7 +38,7 @@ namespace snowhouse {
     return IsLessThanOrEqualToConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer < IsLessThanOrEqualToConstraint< ExpectedType > >
   {
     static std::string ToString(const IsLessThanOrEqualToConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template <typename ExpectedType>
+  template<typename ExpectedType>
   struct StartsWithConstraint : Expression< StartsWithConstraint<ExpectedType> >
   {
     StartsWithConstraint(const ExpectedType& expected)
@@ -24,7 +24,7 @@ namespace snowhouse {
     ExpectedType m_expected;
   };
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   inline StartsWithConstraint<ExpectedType> StartsWith(const ExpectedType& expected)
   {
     return StartsWithConstraint<ExpectedType>(expected);
@@ -35,7 +35,7 @@ namespace snowhouse {
     return StartsWithConstraint<std::string>(expected);
   }
 
-  template< typename ExpectedType >
+  template<typename ExpectedType>
   struct Stringizer< StartsWithConstraint< ExpectedType > >
   {
     static std::string ToString(const StartsWithConstraint<ExpectedType>& constraint)

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct StartsWithConstraint : Expression<StartsWithConstraint<ExpectedType> >
   {
     StartsWithConstraint(const ExpectedType& expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -8,8 +8,8 @@
 
 #include "./expressions/expression.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExpectedType>
   struct StartsWithConstraint : Expression<StartsWithConstraint<ExpectedType> >
   {

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -41,7 +41,7 @@ namespace snowhouse {
     static std::string ToString(const StartsWithConstraint<ExpectedType>& constraint)
     {
       std::ostringstream builder;
-	  builder << "starts with " << snowhouse::Stringize(constraint.m_expected);
+      builder << "starts with " << snowhouse::Stringize(constraint.m_expected);
 
       return builder.str();
     }

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -11,7 +11,7 @@
 namespace snowhouse {
 
   template<typename ExpectedType>
-  struct StartsWithConstraint : Expression< StartsWithConstraint<ExpectedType> >
+  struct StartsWithConstraint : Expression<StartsWithConstraint<ExpectedType> >
   {
     StartsWithConstraint(const ExpectedType& expected)
       : m_expected(expected) {}
@@ -36,7 +36,7 @@ namespace snowhouse {
   }
 
   template<typename ExpectedType>
-  struct Stringizer< StartsWithConstraint< ExpectedType > >
+  struct Stringizer<StartsWithConstraint<ExpectedType> >
   {
     static std::string ToString(const StartsWithConstraint<ExpectedType>& constraint)
     {

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_STARTSWITHCONSTRAINT_H
 #define SNOWHOUSE_STARTSWITHCONSTRAINT_H
 
-#include "./expressions/expression.h"
+#include "expressions/expression.h"
 
 namespace snowhouse
 {

--- a/snowhouse/constraints/startswithconstraint.h
+++ b/snowhouse/constraints/startswithconstraint.h
@@ -14,7 +14,9 @@ namespace snowhouse
   struct StartsWithConstraint : Expression<StartsWithConstraint<ExpectedType> >
   {
     StartsWithConstraint(const ExpectedType& expected)
-      : m_expected(expected) {}
+      : m_expected(expected)
+    {
+    }
 
     bool operator()(const std::string& actual) const
     {

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -74,6 +74,7 @@ namespace snowhouse
   }
 }
 
+// clang-format off
 #define SNOWHOUSE_CONCAT2(a, b) a##b
 #define SNOWHOUSE_CONCAT(a, b) SNOWHOUSE_CONCAT2(a, b)
 
@@ -113,5 +114,6 @@ namespace snowhouse
 # define AssertThrows(EXCEPTION_TYPE, METHOD) \
   SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, (METHOD), ::snowhouse::DefaultFailureHandler)
 #endif
+// clang-format on
 
 #endif

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -10,7 +10,7 @@
 
 namespace snowhouse {
 
-  template <typename ExceptionType>
+  template<typename ExceptionType>
   struct ExceptionStorage
   {
     static void last_exception(ExceptionType*** e, bool clear=false)
@@ -58,7 +58,7 @@ namespace snowhouse {
     }
   };
 
-  template <typename ExceptionType>
+  template<typename ExceptionType>
   inline ExceptionType& LastException()
   {
     ExceptionType** e = NULL;

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -8,8 +8,8 @@
 
 #include "assert.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ExceptionType>
   struct ExceptionStorage
   {

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -13,7 +13,7 @@ namespace snowhouse {
   template<typename ExceptionType>
   struct ExceptionStorage
   {
-    static void last_exception(ExceptionType*** e, bool clear=false)
+    static void last_exception(ExceptionType*** e, bool clear = false)
     {
       static ExceptionType* last = NULL;
       if(clear && last)

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -76,41 +76,40 @@ namespace snowhouse {
 #define SNOWHOUSE_CONCAT(a, b) SNOWHOUSE_CONCAT2(a, b)
 
 #define SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, METHOD, FAILURE_HANDLER_TYPE) \
-::snowhouse::ExceptionStorage<EXCEPTION_TYPE> SNOWHOUSE_CONCAT(SNOWHOUSE_storage_, __LINE__); SNOWHOUSE_CONCAT(SNOWHOUSE_storage_, __LINE__).compiler_thinks_i_am_unused(); \
-{ \
-  bool wrong_exception = false; \
-  bool no_exception = false; \
-  try \
+  ::snowhouse::ExceptionStorage<EXCEPTION_TYPE> SNOWHOUSE_CONCAT(SNOWHOUSE_storage_, __LINE__); SNOWHOUSE_CONCAT(SNOWHOUSE_storage_, __LINE__).compiler_thinks_i_am_unused(); \
   { \
-    METHOD; \
-    no_exception = true; \
-  } \
-  catch (const EXCEPTION_TYPE& snowhouse_exception) \
-  { \
-    ::snowhouse::ExceptionStorage<EXCEPTION_TYPE>::store(snowhouse_exception); \
-  } \
-  catch (...) \
-  { \
-    wrong_exception = true; \
-  } \
-  if (no_exception) \
-  { \
-    std::ostringstream stm; \
-    stm << "Expected " << #EXCEPTION_TYPE << ". No exception was thrown."; \
-    ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
-  } \
-  if (wrong_exception) \
-  { \
-    std::ostringstream stm; \
-    stm << "Expected " << #EXCEPTION_TYPE << ". Wrong exception was thrown."; \
-    ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
-  } \
-}
+    bool wrong_exception = false; \
+    bool no_exception = false; \
+    try \
+    { \
+      METHOD; \
+      no_exception = true; \
+    } \
+    catch (const EXCEPTION_TYPE& snowhouse_exception) \
+    { \
+      ::snowhouse::ExceptionStorage<EXCEPTION_TYPE>::store(snowhouse_exception); \
+    } \
+    catch (...) \
+    { \
+      wrong_exception = true; \
+    } \
+    if (no_exception) \
+    { \
+      std::ostringstream stm; \
+      stm << "Expected " << #EXCEPTION_TYPE << ". No exception was thrown."; \
+      ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
+    } \
+    if (wrong_exception) \
+    { \
+      std::ostringstream stm; \
+      stm << "Expected " << #EXCEPTION_TYPE << ". Wrong exception was thrown."; \
+      ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
+    } \
+  }
 
 #ifndef SNOWHOUSE_NO_MACROS
-
-#define AssertThrows(EXCEPTION_TYPE, METHOD) SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, (METHOD), ::snowhouse::DefaultFailureHandler)
-
-#endif // SNOWHOUSE_NO_MACROS
+# define AssertThrows(EXCEPTION_TYPE, METHOD) \
+  SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, (METHOD), ::snowhouse::DefaultFailureHandler)
+#endif
 
 #endif

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -16,7 +16,7 @@ namespace snowhouse {
     static void last_exception(ExceptionType*** e, bool clear = false)
     {
       static ExceptionType* last = NULL;
-      if(clear && last)
+      if (clear && last)
       {
         delete last;
         return;
@@ -35,7 +35,7 @@ namespace snowhouse {
     {
       ExceptionType** last = NULL;
       last_exception(&last);
-      if(*last)
+      if (*last)
       {
         delete *last;
         *last = NULL;
@@ -50,7 +50,7 @@ namespace snowhouse {
     {
       ExceptionType** e = NULL;
       last_exception(&e);
-      if(*e)
+      if (*e)
       {
         delete *e;
         *e = NULL;
@@ -63,7 +63,7 @@ namespace snowhouse {
   {
     ExceptionType** e = NULL;
     ExceptionStorage<ExceptionType>::last_exception(&e);
-    if(*e == NULL)
+    if (*e == NULL)
     {
       Assert::Failure("No exception was stored");
     }
@@ -89,17 +89,17 @@ namespace snowhouse {
   { \
     ::snowhouse::ExceptionStorage<EXCEPTION_TYPE>::store(snowhouse_exception); \
   } \
-  catch(...) \
+  catch (...) \
   { \
     wrong_exception = true; \
   } \
-  if(no_exception) \
+  if (no_exception) \
   { \
     std::ostringstream stm; \
     stm << "Expected " << #EXCEPTION_TYPE << ". No exception was thrown."; \
     ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \
-  if(wrong_exception) \
+  if (wrong_exception) \
   { \
     std::ostringstream stm; \
     stm << "Expected " << #EXCEPTION_TYPE << ". Wrong exception was thrown."; \

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -44,7 +44,9 @@ namespace snowhouse
       *last = new ExceptionType(e);
     }
 
-    void compiler_thinks_i_am_unused() {}
+    void compiler_thinks_i_am_unused()
+    {
+    }
 
     ~ExceptionStorage()
     {

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -11,9 +11,8 @@
 namespace snowhouse {
 
   template <typename ExceptionType>
-  class ExceptionStorage
+  struct ExceptionStorage
   {
-  public:
     static void last_exception(ExceptionType*** e, bool clear=false)
     {
       static ExceptionType* last = NULL;

--- a/snowhouse/fluent/constraintadapter.h
+++ b/snowhouse/fluent/constraintadapter.h
@@ -9,8 +9,8 @@
 #include "../stringize.h"
 #include "constraintlist.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ConstraintType>
   struct ConstraintAdapter
   {

--- a/snowhouse/fluent/constraintadapter.h
+++ b/snowhouse/fluent/constraintadapter.h
@@ -14,9 +14,8 @@ namespace snowhouse {
   template<typename ConstraintType>
   struct ConstraintAdapter
   {
-    explicit ConstraintAdapter(const ConstraintType& constraint) : m_constraint(constraint)
-    {
-    }
+    explicit ConstraintAdapter(const ConstraintType& constraint)
+      : m_constraint(constraint) {}
 
     template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)

--- a/snowhouse/fluent/constraintadapter.h
+++ b/snowhouse/fluent/constraintadapter.h
@@ -11,14 +11,14 @@
 
 namespace snowhouse {
 
-  template <typename ConstraintType>
+  template<typename ConstraintType>
   struct ConstraintAdapter
   {
     explicit ConstraintAdapter(const ConstraintType& constraint) : m_constraint(constraint)
     {
     }
 
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       result.push(m_constraint(actual));

--- a/snowhouse/fluent/constraintadapter.h
+++ b/snowhouse/fluent/constraintadapter.h
@@ -15,7 +15,7 @@ namespace snowhouse
   struct ConstraintAdapter
   {
     explicit ConstraintAdapter(const ConstraintType& constraint)
-      : m_constraint(constraint)
+        : m_constraint(constraint)
     {
     }
 

--- a/snowhouse/fluent/constraintadapter.h
+++ b/snowhouse/fluent/constraintadapter.h
@@ -15,7 +15,9 @@ namespace snowhouse
   struct ConstraintAdapter
   {
     explicit ConstraintAdapter(const ConstraintType& constraint)
-      : m_constraint(constraint) {}
+      : m_constraint(constraint)
+    {
+    }
 
     template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)

--- a/snowhouse/fluent/constraintadapter.h
+++ b/snowhouse/fluent/constraintadapter.h
@@ -29,7 +29,7 @@ namespace snowhouse {
   };
 
   template<typename ConstraintType>
-  struct Stringizer< ConstraintAdapter<ConstraintType> >
+  struct Stringizer<ConstraintAdapter<ConstraintType> >
   {
     static std::string ToString(const ConstraintAdapter<ConstraintType>& constraintAdapter)
     {

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -21,7 +21,7 @@ namespace snowhouse
     typedef TT TailType;
 
     ConstraintList(const HeadType& head, const TailType& tail)
-      : m_head(head), m_tail(tail)
+        : m_head(head), m_tail(tail)
     {
     }
 

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -8,8 +8,8 @@
 
 #include <stack>
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct ConstraintOperator;
   typedef std::stack<bool> ResultStack;
   typedef std::stack<ConstraintOperator*> OperatorStack;

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -21,7 +21,9 @@ namespace snowhouse
     typedef TT TailType;
 
     ConstraintList(const HeadType& head, const TailType& tail)
-      : m_head(head), m_tail(tail) {}
+      : m_head(head), m_tail(tail)
+    {
+    }
 
     HeadType m_head;
     TailType m_tail;
@@ -29,8 +31,13 @@ namespace snowhouse
 
   struct Nil
   {
-    Nil() {}
-    Nil(const Nil&) {}
+    Nil()
+    {
+    }
+
+    Nil(const Nil&)
+    {
+    }
   };
 
   // ---- These structs defines the resulting types of list concatenation operations

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -3,8 +3,8 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef SNOWHOUSE_CONSTRAINT_H
-#define SNOWHOUSE_CONSTRAINT_H
+#ifndef SNOWHOUSE_CONSTRAINTLIST_H
+#define SNOWHOUSE_CONSTRAINTLIST_H
 
 #include <stack>
 

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -60,7 +60,7 @@ namespace snowhouse {
   {
     static ResultList Concatenate(const LeftList& left, const RightList& right)
     {
-      return ResultList(left.m_head, ListConcat<typename LeftList::TailType, RightList, typename type_concat< typename LeftList::TailType, RightList>::t>::Concatenate(left.m_tail, right));
+      return ResultList(left.m_head, ListConcat<typename LeftList::TailType, RightList, typename type_concat<typename LeftList::TailType, RightList>::t>::Concatenate(left.m_tail, right));
     }
   };
 

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -14,7 +14,7 @@ namespace snowhouse {
   typedef std::stack<bool> ResultStack;
   typedef std::stack<ConstraintOperator*> OperatorStack;
 
-  template <typename HT, typename TT>
+  template<typename HT, typename TT>
   struct ConstraintList
   {
     typedef HT HeadType;
@@ -37,20 +37,20 @@ namespace snowhouse {
 
 
   // ---- These structs defines the resulting types of list concatenation operations
-  template <typename L1, typename L2>
+  template<typename L1, typename L2>
   struct type_concat
   {
     typedef ConstraintList<typename L1::HeadType, typename type_concat<typename L1::TailType, L2>::t> t;
   };
 
-  template <typename L2> struct type_concat<Nil, L2> { typedef L2 t; };
+  template<typename L2> struct type_concat<Nil, L2> { typedef L2 t; };
 
-  template <typename L3> inline L3 tr_concat(const Nil&, const Nil&) { return Nil(); }
+  template<typename L3> inline L3 tr_concat(const Nil&, const Nil&) { return Nil(); }
 
 
   // ---- These structs define the concatenation operations.
 
-  template <typename LeftList, typename RightList, typename ResultList>
+  template<typename LeftList, typename RightList, typename ResultList>
   struct ListConcat
   {
     static ResultList Concatenate(const LeftList& left, const RightList& right)
@@ -60,7 +60,7 @@ namespace snowhouse {
   };
 
   // Concatenating an empty list with a second list yields the second list
-  template <typename RightList, typename ResultList>
+  template<typename RightList, typename ResultList>
   struct ListConcat<Nil, RightList, ResultList>
   {
     static ResultList Concatenate(const Nil&, const RightList& right)
@@ -71,7 +71,7 @@ namespace snowhouse {
   };
 
   // Concatenating two empty lists yields an empty list
-  template <typename ResultList>
+  template<typename ResultList>
   struct ListConcat<Nil, Nil, ResultList>
   {
     static ResultList Concatenate(const Nil&, const Nil&)
@@ -82,7 +82,7 @@ namespace snowhouse {
 
   // ---- The concatenation operation
 
-  template <typename L1, typename L2>
+  template<typename L1, typename L2>
   inline typename type_concat<L1, L2>::t Concatenate(const L1& list1, const L2& list2)
   {
     return ListConcat<L1, L2, typename type_concat<L1, L2>::t>::Concatenate(list1, list2);

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -43,9 +43,14 @@ namespace snowhouse {
     typedef ConstraintList<typename L1::HeadType, typename type_concat<typename L1::TailType, L2>::t> t;
   };
 
-  template<typename L2> struct type_concat<Nil, L2> { typedef L2 t; };
+  template<typename L2>
+  struct type_concat<Nil, L2>
+  {
+    typedef L2 t;
+  };
 
-  template<typename L3> inline L3 tr_concat(const Nil&, const Nil&) { return Nil(); }
+  template<typename L3>
+  inline L3 tr_concat(const Nil&, const Nil&) { return Nil(); }
 
 
   // ---- These structs define the concatenation operations.

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -21,7 +21,7 @@ namespace snowhouse {
     typedef TT TailType;
 
     ConstraintList(const HeadType& head, const TailType& tail)
-    : m_head(head), m_tail(tail)
+      : m_head(head), m_tail(tail)
     {
     }
 

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -21,9 +21,7 @@ namespace snowhouse {
     typedef TT TailType;
 
     ConstraintList(const HeadType& head, const TailType& tail)
-      : m_head(head), m_tail(tail)
-    {
-    }
+      : m_head(head), m_tail(tail) {}
 
     HeadType m_head;
     TailType m_tail;

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -33,7 +33,6 @@ namespace snowhouse {
     Nil(const Nil&) {}
   };
 
-
   // ---- These structs defines the resulting types of list concatenation operations
   template<typename L1, typename L2>
   struct type_concat
@@ -52,7 +51,6 @@ namespace snowhouse {
   {
     return Nil();
   }
-
 
   // ---- These structs define the concatenation operations.
 
@@ -73,7 +71,6 @@ namespace snowhouse {
     {
       return right;
     }
-
   };
 
   // Concatenating two empty lists yields an empty list

--- a/snowhouse/fluent/constraintlist.h
+++ b/snowhouse/fluent/constraintlist.h
@@ -50,7 +50,10 @@ namespace snowhouse {
   };
 
   template<typename L3>
-  inline L3 tr_concat(const Nil&, const Nil&) { return Nil(); }
+  inline L3 tr_concat(const Nil&, const Nil&)
+  {
+    return Nil();
+  }
 
 
   // ---- These structs define the concatenation operations.

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -30,7 +30,6 @@ namespace snowhouse {
   template<typename ActualType>
   inline void EvaluateConstraintList(Nil&, ResultStack&, OperatorStack&, const ActualType&) {}
 
-
   template<typename ConstraintListType>
   struct ExpressionBuilder
   {

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -34,9 +34,8 @@ namespace snowhouse {
   template<typename ConstraintListType>
   struct ExpressionBuilder
   {
-    explicit ExpressionBuilder(const ConstraintListType& list) : m_constraint_list(list)
-    {
-    }
+    explicit ExpressionBuilder(const ConstraintListType& list)
+      : m_constraint_list(list) {}
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<ExpectedType> >, Nil> >::t>
@@ -345,9 +344,7 @@ namespace snowhouse {
     StringizeConstraintList(list.m_tail, stm);
   }
 
-  inline void StringizeConstraintList(const Nil&, std::ostringstream&)
-  {
-  }
+  inline void StringizeConstraintList(const Nil&, std::ostringstream&) {}
 
   template<typename ConstraintListType>
   struct Stringizer<ExpressionBuilder<ConstraintListType> >

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -17,8 +17,8 @@
 #include "operators/collections/exactlyoperator.h"
 #include "operators/collections/atmostoperator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   // ---- Evaluation of list of constraints
 
   template<typename ConstraintListType, typename ActualType>

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -28,13 +28,17 @@ namespace snowhouse
   }
 
   template<typename ActualType>
-  inline void EvaluateConstraintList(Nil&, ResultStack&, OperatorStack&, const ActualType&) {}
+  inline void EvaluateConstraintList(Nil&, ResultStack&, OperatorStack&, const ActualType&)
+  {
+  }
 
   template<typename ConstraintListType>
   struct ExpressionBuilder
   {
     explicit ExpressionBuilder(const ConstraintListType& list)
-      : m_constraint_list(list) {}
+      : m_constraint_list(list)
+    {
+    }
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<ExpectedType> >, Nil> >::t>
@@ -343,7 +347,9 @@ namespace snowhouse
     StringizeConstraintList(list.m_tail, stm);
   }
 
-  inline void StringizeConstraintList(const Nil&, std::ostringstream&) {}
+  inline void StringizeConstraintList(const Nil&, std::ostringstream&)
+  {
+  }
 
   template<typename ConstraintListType>
   struct Stringizer<ExpressionBuilder<ConstraintListType> >

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -43,7 +43,7 @@ namespace snowhouse {
       EqualTo(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<EqualsConstraint<ExpectedType> > ConstraintAdapterType;
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
 
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
@@ -56,7 +56,7 @@ namespace snowhouse {
       EqualToWithDelta(const ExpectedType& expected, const DeltaType& delta)
     {
       typedef ConstraintAdapter<EqualsWithDeltaConstraint<ExpectedType, DeltaType> > ConstraintAdapterType;
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
 
       ConstraintAdapterType constraint(EqualsWithDeltaConstraint<ExpectedType, DeltaType>(expected, delta));
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
@@ -69,7 +69,7 @@ namespace snowhouse {
       Fulfilling(const MatcherType& matcher)
     {
       typedef ConstraintAdapter<FulfillsConstraint<MatcherType> > ConstraintAdapterType;
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
 
       ConstraintAdapterType constraint(matcher);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
@@ -109,7 +109,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -121,7 +121,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -133,7 +133,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<IsLessThanConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -145,7 +145,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -157,7 +157,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<ContainsConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -174,7 +174,7 @@ namespace snowhouse {
       EndingWith(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<EndsWithConstraint<ExpectedType> > ConstraintAdapterType;
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
 
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
@@ -193,7 +193,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<StartsWithConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -211,7 +211,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<HasLengthConstraint<ExpectedType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(expected);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -222,7 +222,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<HasLengthConstraint<int> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(0);
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -235,7 +235,7 @@ namespace snowhouse {
       typedef bool (*DefaultBinaryPredivateType)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&);
       typedef ConstraintAdapter<EqualsContainerConstraint<ExpectedType, DefaultBinaryPredivateType> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(EqualsContainerConstraint<ExpectedType, DefaultBinaryPredivateType>(expected, constraint_internal::default_comparer<typename ExpectedType::value_type>));
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -247,7 +247,7 @@ namespace snowhouse {
     {
       typedef ConstraintAdapter<EqualsContainerConstraint<ExpectedType, BinaryPredicate> > ConstraintAdapterType;
 
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
       ConstraintAdapterType constraint(EqualsContainerConstraint<ExpectedType, BinaryPredicate>(expected, predicate));
       ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
       return BuilderType(Concatenate(m_constraint_list, node));
@@ -350,7 +350,7 @@ namespace snowhouse {
   }
 
   template<typename ConstraintListType>
-  struct Stringizer< ExpressionBuilder<ConstraintListType> >
+  struct Stringizer<ExpressionBuilder<ConstraintListType> >
   {
     static std::string ToString(const ExpressionBuilder<ConstraintListType>& builder)
     {

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -21,24 +21,24 @@ namespace snowhouse {
 
   // ---- Evaluation of list of constraints
 
-  template <typename ConstraintListType, typename ActualType>
+  template<typename ConstraintListType, typename ActualType>
   inline void EvaluateConstraintList(ConstraintListType& constraint_list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
   {
     constraint_list.m_head.Evaluate(constraint_list, result, operators, actual);
   }
 
-  template <typename ActualType>
+  template<typename ActualType>
   inline void EvaluateConstraintList(Nil&, ResultStack&, OperatorStack&, const ActualType&) {}
 
 
-  template <typename ConstraintListType>
+  template<typename ConstraintListType>
   struct ExpressionBuilder
   {
     explicit ExpressionBuilder(const ConstraintListType& list) : m_constraint_list(list)
     {
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<ExpectedType> >, Nil> >::t>
       EqualTo(const ExpectedType& expected)
     {
@@ -51,7 +51,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType, typename DeltaType>
+    template<typename ExpectedType, typename DeltaType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >, Nil> >::t>
       EqualToWithDelta(const ExpectedType& expected, const DeltaType& delta)
     {
@@ -64,7 +64,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename MatcherType>
+    template<typename MatcherType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<FulfillsConstraint<MatcherType> >, Nil> >::t>
       Fulfilling(const MatcherType& matcher)
     {
@@ -103,7 +103,7 @@ namespace snowhouse {
       return EqualTo<std::string>(std::string(expected));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> >, Nil> >::t>
       GreaterThan(const ExpectedType& expected)
     {
@@ -115,7 +115,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
       GreaterThanOrEqualTo(const ExpectedType& expected)
     {
@@ -127,7 +127,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanConstraint<ExpectedType> >, Nil> >::t>
       LessThan(const ExpectedType& expected)
     {
@@ -139,7 +139,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
       LessThanOrEqualTo(const ExpectedType& expected)
     {
@@ -151,7 +151,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<ContainsConstraint<ExpectedType> >, Nil> >::t>
       Containing(const ExpectedType& expected)
     {
@@ -169,7 +169,7 @@ namespace snowhouse {
       return Containing<std::string>(std::string(expected));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EndsWithConstraint<ExpectedType> >, Nil> >::t>
       EndingWith(const ExpectedType& expected)
     {
@@ -187,7 +187,7 @@ namespace snowhouse {
       return EndingWith(std::string(expected));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<StartsWithConstraint<ExpectedType> >, Nil> >::t>
       StartingWith(const ExpectedType& expected)
     {
@@ -205,7 +205,7 @@ namespace snowhouse {
       return StartingWith(std::string(expected));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<HasLengthConstraint<ExpectedType> >, Nil> >::t>
       OfLength(const ExpectedType& expected)
     {
@@ -228,7 +228,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType>
+    template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)> >, Nil> >::t>
       EqualToContainer(const ExpectedType& expected)
     {
@@ -241,7 +241,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ExpectedType, typename BinaryPredicate>
+    template<typename ExpectedType, typename BinaryPredicate>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >, Nil> >::t>
       EqualToContainer(const ExpectedType& expected, const BinaryPredicate predicate)
     {
@@ -326,7 +326,7 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-    template <typename ActualType>
+    template<typename ActualType>
     void Evaluate(ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       EvaluateConstraintList(m_constraint_list, result, operators, actual);
@@ -335,7 +335,7 @@ namespace snowhouse {
     ConstraintListType m_constraint_list;
   };
 
-  template <typename T>
+  template<typename T>
   inline void StringizeConstraintList(const T& list, std::ostringstream& stm)
   {
     if (stm.tellp() > 0)

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -36,7 +36,7 @@ namespace snowhouse
   struct ExpressionBuilder
   {
     explicit ExpressionBuilder(const ConstraintListType& list)
-      : m_constraint_list(list)
+        : m_constraint_list(list)
     {
     }
 

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -103,33 +103,33 @@ namespace snowhouse {
       return EqualTo<std::string>(std::string(expected));
     }
 
-	template <typename ExpectedType>
-	ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> >, Nil> >::t>
-		GreaterThan(const ExpectedType& expected)
-	{
-		typedef ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> > ConstraintAdapterType;
+    template <typename ExpectedType>
+    ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> >, Nil> >::t>
+      GreaterThan(const ExpectedType& expected)
+    {
+      typedef ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> > ConstraintAdapterType;
 
-		typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
-		ConstraintAdapterType constraint(expected);
-		ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
-		return BuilderType(Concatenate(m_constraint_list, node));
-	}
+      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      ConstraintAdapterType constraint(expected);
+      ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
+      return BuilderType(Concatenate(m_constraint_list, node));
+    }
 
-	template <typename ExpectedType>
-	ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
-		GreaterThanOrEqualTo(const ExpectedType& expected)
-	{
-		typedef ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
+    template <typename ExpectedType>
+    ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
+      GreaterThanOrEqualTo(const ExpectedType& expected)
+    {
+      typedef ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
 
-		typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
-		ConstraintAdapterType constraint(expected);
-		ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
-		return BuilderType(Concatenate(m_constraint_list, node));
-	}
+      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      ConstraintAdapterType constraint(expected);
+      ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
+      return BuilderType(Concatenate(m_constraint_list, node));
+    }
 
     template <typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanConstraint<ExpectedType> >, Nil> >::t>
-    LessThan(const ExpectedType& expected)
+      LessThan(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<IsLessThanConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -139,17 +139,17 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     }
 
-	template <typename ExpectedType>
-	ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
-		LessThanOrEqualTo(const ExpectedType& expected)
-	{
-		typedef ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
+    template <typename ExpectedType>
+    ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
+      LessThanOrEqualTo(const ExpectedType& expected)
+    {
+      typedef ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
 
-		typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
-		ConstraintAdapterType constraint(expected);
-		ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
-		return BuilderType(Concatenate(m_constraint_list, node));
-	}
+      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+      ConstraintAdapterType constraint(expected);
+      ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
+      return BuilderType(Concatenate(m_constraint_list, node));
+    }
 
     template <typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<ContainsConstraint<ExpectedType> >, Nil> >::t>
@@ -164,7 +164,7 @@ namespace snowhouse {
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<ContainsConstraint<std::string> >, Nil> >::t>
-    Containing(const char* expected)
+      Containing(const char* expected)
     {
       return Containing<std::string>(std::string(expected));
     }
@@ -339,7 +339,7 @@ namespace snowhouse {
   inline void StringizeConstraintList(const T& list, std::ostringstream& stm)
   {
     if (stm.tellp() > 0)
-	  stm << " ";
+      stm << " ";
 
     stm << snowhouse::Stringize(list.m_head);
     StringizeConstraintList(list.m_tail, stm);
@@ -357,7 +357,7 @@ namespace snowhouse {
       std::ostringstream stm;
       StringizeConstraintList(builder.m_constraint_list, stm);
 
-	  return stm.str();
+      return stm.str();
     }
   };
 }

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -38,7 +38,7 @@ namespace snowhouse {
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<ExpectedType> >, Nil> >::t>
-      EqualTo(const ExpectedType& expected)
+    EqualTo(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<EqualsConstraint<ExpectedType> > ConstraintAdapterType;
       typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
@@ -51,7 +51,7 @@ namespace snowhouse {
 
     template<typename ExpectedType, typename DeltaType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsWithDeltaConstraint<ExpectedType, DeltaType> >, Nil> >::t>
-      EqualToWithDelta(const ExpectedType& expected, const DeltaType& delta)
+    EqualToWithDelta(const ExpectedType& expected, const DeltaType& delta)
     {
       typedef ConstraintAdapter<EqualsWithDeltaConstraint<ExpectedType, DeltaType> > ConstraintAdapterType;
       typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
@@ -64,7 +64,7 @@ namespace snowhouse {
 
     template<typename MatcherType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<FulfillsConstraint<MatcherType> >, Nil> >::t>
-      Fulfilling(const MatcherType& matcher)
+    Fulfilling(const MatcherType& matcher)
     {
       typedef ConstraintAdapter<FulfillsConstraint<MatcherType> > ConstraintAdapterType;
       typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
@@ -76,34 +76,34 @@ namespace snowhouse {
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<bool> >, Nil> >::t>
-      False()
+    False()
     {
       return EqualTo<bool>(false);
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<bool> >, Nil> >::t>
-      True()
+    True()
     {
       return EqualTo<bool>(true);
     }
 
 #ifdef SNOWHOUSE_HAS_NULLPTR
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<std::nullptr_t> >, Nil> >::t>
-      Null()
+    Null()
     {
       return EqualTo<std::nullptr_t>(nullptr);
     }
 #endif
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<std::string> >, Nil> >::t>
-      EqualTo(const char* expected)
+    EqualTo(const char* expected)
     {
       return EqualTo<std::string>(std::string(expected));
     }
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> >, Nil> >::t>
-      GreaterThan(const ExpectedType& expected)
+    GreaterThan(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -115,7 +115,7 @@ namespace snowhouse {
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
-      GreaterThanOrEqualTo(const ExpectedType& expected)
+    GreaterThanOrEqualTo(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -127,7 +127,7 @@ namespace snowhouse {
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanConstraint<ExpectedType> >, Nil> >::t>
-      LessThan(const ExpectedType& expected)
+    LessThan(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<IsLessThanConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -139,7 +139,7 @@ namespace snowhouse {
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
-      LessThanOrEqualTo(const ExpectedType& expected)
+    LessThanOrEqualTo(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -151,7 +151,7 @@ namespace snowhouse {
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<ContainsConstraint<ExpectedType> >, Nil> >::t>
-      Containing(const ExpectedType& expected)
+    Containing(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<ContainsConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -162,14 +162,14 @@ namespace snowhouse {
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<ContainsConstraint<std::string> >, Nil> >::t>
-      Containing(const char* expected)
+    Containing(const char* expected)
     {
       return Containing<std::string>(std::string(expected));
     }
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EndsWithConstraint<ExpectedType> >, Nil> >::t>
-      EndingWith(const ExpectedType& expected)
+    EndingWith(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<EndsWithConstraint<ExpectedType> > ConstraintAdapterType;
       typedef ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t> BuilderType;
@@ -180,14 +180,14 @@ namespace snowhouse {
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EndsWithConstraint<std::string> >, Nil> >::t>
-      EndingWith(const char* expected)
+    EndingWith(const char* expected)
     {
       return EndingWith(std::string(expected));
     }
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<StartsWithConstraint<ExpectedType> >, Nil> >::t>
-      StartingWith(const ExpectedType& expected)
+    StartingWith(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<StartsWithConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -198,14 +198,14 @@ namespace snowhouse {
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<StartsWithConstraint<std::string> >, Nil> >::t>
-      StartingWith(const char* expected)
+    StartingWith(const char* expected)
     {
       return StartingWith(std::string(expected));
     }
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<HasLengthConstraint<ExpectedType> >, Nil> >::t>
-      OfLength(const ExpectedType& expected)
+    OfLength(const ExpectedType& expected)
     {
       typedef ConstraintAdapter<HasLengthConstraint<ExpectedType> > ConstraintAdapterType;
 
@@ -216,7 +216,7 @@ namespace snowhouse {
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<HasLengthConstraint<int> >, Nil> >::t>
-      Empty()
+    Empty()
     {
       typedef ConstraintAdapter<HasLengthConstraint<int> > ConstraintAdapterType;
 
@@ -228,7 +228,7 @@ namespace snowhouse {
 
     template<typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsContainerConstraint<ExpectedType, bool (*)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&)> >, Nil> >::t>
-      EqualToContainer(const ExpectedType& expected)
+    EqualToContainer(const ExpectedType& expected)
     {
       typedef bool (*DefaultBinaryPredivateType)(const typename ExpectedType::value_type&, const typename ExpectedType::value_type&);
       typedef ConstraintAdapter<EqualsContainerConstraint<ExpectedType, DefaultBinaryPredivateType> > ConstraintAdapterType;
@@ -241,7 +241,7 @@ namespace snowhouse {
 
     template<typename ExpectedType, typename BinaryPredicate>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsContainerConstraint<ExpectedType, BinaryPredicate> >, Nil> >::t>
-      EqualToContainer(const ExpectedType& expected, const BinaryPredicate predicate)
+    EqualToContainer(const ExpectedType& expected, const BinaryPredicate predicate)
     {
       typedef ConstraintAdapter<EqualsContainerConstraint<ExpectedType, BinaryPredicate> > ConstraintAdapterType;
 

--- a/snowhouse/fluent/fluent.h
+++ b/snowhouse/fluent/fluent.h
@@ -19,7 +19,6 @@ namespace snowhouse {
   {
     return ExpressionBuilder<Nil>(Nil());
   }
-
 }
 
 #endif

--- a/snowhouse/fluent/fluent.h
+++ b/snowhouse/fluent/fluent.h
@@ -17,7 +17,7 @@ namespace snowhouse {
 
   inline ExpressionBuilder<Nil> Has()
   {
-     return ExpressionBuilder<Nil>(Nil());
+    return ExpressionBuilder<Nil>(Nil());
   }
 
 }

--- a/snowhouse/fluent/fluent.h
+++ b/snowhouse/fluent/fluent.h
@@ -8,8 +8,8 @@
 
 #include "expressionbuilder.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   inline ExpressionBuilder<Nil> Is()
   {
     return ExpressionBuilder<Nil>(Nil());

--- a/snowhouse/fluent/operators/andoperator.h
+++ b/snowhouse/fluent/operators/andoperator.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_ANDOPERATOR_H
 #define SNOWHOUSE_ANDOPERATOR_H
 
-#include "./constraintoperator.h"
+#include "constraintoperator.h"
 
 namespace snowhouse
 {

--- a/snowhouse/fluent/operators/andoperator.h
+++ b/snowhouse/fluent/operators/andoperator.h
@@ -12,7 +12,7 @@ namespace snowhouse {
 
   struct AndOperator : public ConstraintOperator
   {
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       EvaluateOperatorsWithLessOrEqualPrecedence(*this, operators, result);

--- a/snowhouse/fluent/operators/andoperator.h
+++ b/snowhouse/fluent/operators/andoperator.h
@@ -24,7 +24,7 @@ namespace snowhouse {
 
     void PerformOperation(ResultStack& result)
     {
-      if(result.size() < 2)
+      if (result.size() < 2)
       {
         throw InvalidExpressionException("The expression contains an and operator with too few operands");
       }

--- a/snowhouse/fluent/operators/andoperator.h
+++ b/snowhouse/fluent/operators/andoperator.h
@@ -43,13 +43,13 @@ namespace snowhouse {
     }
   };
 
-   template<>
-   struct Stringizer<AndOperator>
-   {
-      static std::string ToString(const AndOperator&)
-      {
-        return "and";
-      }
-   };
+  template<>
+  struct Stringizer<AndOperator>
+  {
+    static std::string ToString(const AndOperator&)
+    {
+      return "and";
+    }
+  };
 }
 #endif

--- a/snowhouse/fluent/operators/andoperator.h
+++ b/snowhouse/fluent/operators/andoperator.h
@@ -8,8 +8,8 @@
 
 #include "./constraintoperator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct AndOperator : public ConstraintOperator
   {
     template<typename ConstraintListType, typename ActualType>

--- a/snowhouse/fluent/operators/collections/alloperator.h
+++ b/snowhouse/fluent/operators/collections/alloperator.h
@@ -11,25 +11,25 @@
 
 namespace snowhouse {
 
-   struct AllOperator : public CollectionOperator
-   {
-      template <typename ConstraintListType, typename ActualType>
-      void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
-      {
-         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+  struct AllOperator : public CollectionOperator
+  {
+    template <typename ConstraintListType, typename ActualType>
+    void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
+    {
+      unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
-         result.push(passed_elements == actual.size());
-      }
-   };
+      result.push(passed_elements == actual.size());
+    }
+  };
 
-   template<>
-   struct Stringizer<AllOperator>
-   {
-      static std::string ToString(const AllOperator&)
-      {
-         return "all";
-      }
-   };
+  template<>
+  struct Stringizer<AllOperator>
+  {
+    static std::string ToString(const AllOperator&)
+    {
+      return "all";
+    }
+  };
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/alloperator.h
+++ b/snowhouse/fluent/operators/collections/alloperator.h
@@ -16,7 +16,7 @@ namespace snowhouse {
       template <typename ConstraintListType, typename ActualType>
       void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
       {
-        unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
          result.push(passed_elements == actual.size());
       }
@@ -27,7 +27,7 @@ namespace snowhouse {
    {
       static std::string ToString(const AllOperator&)
       {
-        return "all";
+         return "all";
       }
    };
 }

--- a/snowhouse/fluent/operators/collections/alloperator.h
+++ b/snowhouse/fluent/operators/collections/alloperator.h
@@ -13,7 +13,7 @@ namespace snowhouse {
 
   struct AllOperator : public CollectionOperator
   {
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);

--- a/snowhouse/fluent/operators/collections/alloperator.h
+++ b/snowhouse/fluent/operators/collections/alloperator.h
@@ -9,8 +9,8 @@
 #include "collectionoperator.h"
 #include "collectionconstraintevaluator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct AllOperator : public CollectionOperator
   {
     template<typename ConstraintListType, typename ActualType>

--- a/snowhouse/fluent/operators/collections/atleastoperator.h
+++ b/snowhouse/fluent/operators/collections/atleastoperator.h
@@ -11,31 +11,31 @@
 
 namespace snowhouse {
 
-   struct AtLeastOperator : public CollectionOperator
-   {
-      explicit AtLeastOperator(unsigned int expected) : m_expected(expected) {}
+  struct AtLeastOperator : public CollectionOperator
+  {
+    explicit AtLeastOperator(unsigned int expected) : m_expected(expected) {}
 
-      template <typename ConstraintListType, typename ActualType>
-      void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
-      {
-         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+    template <typename ConstraintListType, typename ActualType>
+    void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
+    {
+      unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
-         result.push(passed_elements >= m_expected);
-      }
+      result.push(passed_elements >= m_expected);
+    }
 
-      unsigned int m_expected;
-   };
+    unsigned int m_expected;
+  };
 
-   template<>
-   struct Stringizer<AtLeastOperator>
-   {
-      static std::string ToString(const AtLeastOperator& op)
-      {
-         std::ostringstream stm;
-         stm << "at least " << op.m_expected;
-         return stm.str();
-      }
-   };
+  template<>
+  struct Stringizer<AtLeastOperator>
+  {
+    static std::string ToString(const AtLeastOperator& op)
+    {
+      std::ostringstream stm;
+      stm << "at least " << op.m_expected;
+      return stm.str();
+    }
+  };
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/atleastoperator.h
+++ b/snowhouse/fluent/operators/collections/atleastoperator.h
@@ -18,7 +18,7 @@ namespace snowhouse {
       template <typename ConstraintListType, typename ActualType>
       void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
       {
-        unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
          result.push(passed_elements >= m_expected);
       }

--- a/snowhouse/fluent/operators/collections/atleastoperator.h
+++ b/snowhouse/fluent/operators/collections/atleastoperator.h
@@ -9,8 +9,8 @@
 #include "collectionoperator.h"
 #include "collectionconstraintevaluator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct AtLeastOperator : public CollectionOperator
   {
     explicit AtLeastOperator(unsigned int expected) : m_expected(expected) {}

--- a/snowhouse/fluent/operators/collections/atleastoperator.h
+++ b/snowhouse/fluent/operators/collections/atleastoperator.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct AtLeastOperator : public CollectionOperator
   {
     explicit AtLeastOperator(unsigned int expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/fluent/operators/collections/atleastoperator.h
+++ b/snowhouse/fluent/operators/collections/atleastoperator.h
@@ -15,7 +15,7 @@ namespace snowhouse {
   {
     explicit AtLeastOperator(unsigned int expected) : m_expected(expected) {}
 
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);

--- a/snowhouse/fluent/operators/collections/atleastoperator.h
+++ b/snowhouse/fluent/operators/collections/atleastoperator.h
@@ -13,7 +13,10 @@ namespace snowhouse
 {
   struct AtLeastOperator : public CollectionOperator
   {
-    explicit AtLeastOperator(unsigned int expected) : m_expected(expected) {}
+    explicit AtLeastOperator(unsigned int expected)
+      : m_expected(expected)
+    {
+    }
 
     template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)

--- a/snowhouse/fluent/operators/collections/atmostoperator.h
+++ b/snowhouse/fluent/operators/collections/atmostoperator.h
@@ -13,7 +13,10 @@ namespace snowhouse
 {
   struct AtMostOperator : public CollectionOperator
   {
-    explicit AtMostOperator(unsigned int expected) : m_expected(expected) {}
+    explicit AtMostOperator(unsigned int expected)
+      : m_expected(expected)
+    {
+    }
 
     template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)

--- a/snowhouse/fluent/operators/collections/atmostoperator.h
+++ b/snowhouse/fluent/operators/collections/atmostoperator.h
@@ -9,8 +9,8 @@
 #include "collectionoperator.h"
 #include "collectionconstraintevaluator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct AtMostOperator : public CollectionOperator
   {
     explicit AtMostOperator(unsigned int expected) : m_expected(expected) {}

--- a/snowhouse/fluent/operators/collections/atmostoperator.h
+++ b/snowhouse/fluent/operators/collections/atmostoperator.h
@@ -11,31 +11,31 @@
 
 namespace snowhouse {
 
-   struct AtMostOperator : public CollectionOperator
-   {
-      explicit AtMostOperator(unsigned int expected) : m_expected(expected) {}
+  struct AtMostOperator : public CollectionOperator
+  {
+    explicit AtMostOperator(unsigned int expected) : m_expected(expected) {}
 
-      template <typename ConstraintListType, typename ActualType>
-      void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
-      {
-         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+    template <typename ConstraintListType, typename ActualType>
+    void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
+    {
+      unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
-         result.push(passed_elements <= m_expected);
-      }
+      result.push(passed_elements <= m_expected);
+    }
 
-      unsigned int m_expected;
-   };
+    unsigned int m_expected;
+  };
 
-   template<>
-   struct Stringizer<AtMostOperator>
-   {
-      static std::string ToString(const AtMostOperator& op)
-      {
-         std::ostringstream stm;
-         stm << "at most " << op.m_expected;
-         return stm.str();
-      }
-   };
+  template<>
+  struct Stringizer<AtMostOperator>
+  {
+    static std::string ToString(const AtMostOperator& op)
+    {
+      std::ostringstream stm;
+      stm << "at most " << op.m_expected;
+      return stm.str();
+    }
+  };
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/atmostoperator.h
+++ b/snowhouse/fluent/operators/collections/atmostoperator.h
@@ -18,7 +18,7 @@ namespace snowhouse {
       template <typename ConstraintListType, typename ActualType>
       void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
       {
-        unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
          result.push(passed_elements <= m_expected);
       }

--- a/snowhouse/fluent/operators/collections/atmostoperator.h
+++ b/snowhouse/fluent/operators/collections/atmostoperator.h
@@ -15,7 +15,7 @@ namespace snowhouse {
   {
     explicit AtMostOperator(unsigned int expected) : m_expected(expected) {}
 
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);

--- a/snowhouse/fluent/operators/collections/atmostoperator.h
+++ b/snowhouse/fluent/operators/collections/atmostoperator.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct AtMostOperator : public CollectionOperator
   {
     explicit AtMostOperator(unsigned int expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -88,7 +88,8 @@ namespace snowhouse
 
       std::ostringstream stm;
       stm << "This string seems to contain an invalid line ending at position "
-          << newline << ":\n" << str << std::endl;
+          << newline << ":" << std::endl
+          << str << std::endl;
       throw InvalidExpressionException(stm.str());
     }
   };

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -10,8 +10,8 @@
 
 #include "../constraintoperator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   template<typename ConstraintListType, typename ActualType>
   struct CollectionConstraintEvaluator
   {

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -106,7 +106,6 @@ namespace snowhouse {
       return CollectionConstraintEvaluator<ConstraintListType, std::vector<std::string> >::Evaluate(op, expression, result, operators, lines);
     }
   };
-
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -24,10 +24,9 @@ namespace snowhouse {
 
       unsigned int passed_elements = 0;
       typename ActualType::const_iterator it;
-      for(it = actual.begin(); it != actual.end(); ++it)
+      for (it = actual.begin(); it != actual.end(); ++it)
       {
-        if(ConstraintOperator::EvaluateElementAgainstRestOfExpression(expression,
-            *it))
+        if (ConstraintOperator::EvaluateElementAgainstRestOfExpression(expression, *it))
         {
           ++passed_elements;
         }
@@ -44,14 +43,14 @@ namespace snowhouse {
       size_t start = 0;
       size_t newline = FindNewline(str, start);
 
-      while(newline != std::string::npos)
+      while (newline != std::string::npos)
       {
         StoreLine(str, start, newline, res);
         start = MoveToNextLine(str, newline);
         newline = FindNewline(str, start);
       }
 
-      if(start < str.size())
+      if (start < str.size())
       {
         StoreLine(str, start, std::string::npos, res);
       }
@@ -72,17 +71,17 @@ namespace snowhouse {
 
     static size_t MoveToNextLine(const std::string& str, size_t newline)
     {
-      if(str.find("\r\n", newline) == newline)
+      if (str.find("\r\n", newline) == newline)
       {
         return newline + 2;
       }
 
-      if(str.find("\n", newline) == newline)
+      if (str.find("\n", newline) == newline)
       {
         return newline + 1;
       }
 
-      if(str.find("\r", newline) == newline)
+      if (str.find("\r", newline) == newline)
       {
         return newline + 1;
       }

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -10,8 +10,7 @@
 
 #include "../constraintoperator.h"
 
-namespace snowhouse
-{
+namespace snowhouse {
 
 template<typename ConstraintListType, typename ActualType>
 struct CollectionConstraintEvaluator

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -12,100 +12,100 @@
 
 namespace snowhouse {
 
-template<typename ConstraintListType, typename ActualType>
-struct CollectionConstraintEvaluator
-{
-  static unsigned int Evaluate(const ConstraintOperator& op,
-      ConstraintListType& expression, ResultStack& result,
-      OperatorStack& operators, const ActualType& actual)
+  template<typename ConstraintListType, typename ActualType>
+  struct CollectionConstraintEvaluator
   {
-    ConstraintOperator::EvaluateOperatorsWithLessOrEqualPrecedence(op,
-        operators, result);
-
-    unsigned int passed_elements = 0;
-    typename ActualType::const_iterator it;
-    for(it = actual.begin(); it != actual.end(); ++it)
+    static unsigned int Evaluate(const ConstraintOperator& op,
+        ConstraintListType& expression, ResultStack& result,
+        OperatorStack& operators, const ActualType& actual)
     {
-      if(ConstraintOperator::EvaluateElementAgainstRestOfExpression(expression,
-          *it))
+      ConstraintOperator::EvaluateOperatorsWithLessOrEqualPrecedence(op,
+          operators, result);
+
+      unsigned int passed_elements = 0;
+      typename ActualType::const_iterator it;
+      for(it = actual.begin(); it != actual.end(); ++it)
       {
-        ++passed_elements;
+        if(ConstraintOperator::EvaluateElementAgainstRestOfExpression(expression,
+            *it))
+        {
+          ++passed_elements;
+        }
+      }
+
+      return passed_elements;
+    }
+  };
+
+  struct StringLineParser
+  {
+    static void Parse(const std::string& str, std::vector<std::string>& res)
+    {
+      size_t start = 0;
+      size_t newline = FindNewline(str, start);
+
+      while(newline != std::string::npos)
+      {
+        StoreLine(str, start, newline, res);
+        start = MoveToNextLine(str, newline);
+        newline = FindNewline(str, start);
+      }
+
+      if(start < str.size())
+      {
+        StoreLine(str, start, std::string::npos, res);
       }
     }
 
-    return passed_elements;
-  }
-};
-
-struct StringLineParser
-{
-  static void Parse(const std::string& str, std::vector<std::string>& res)
-  {
-    size_t start = 0;
-    size_t newline = FindNewline(str, start);
-
-    while(newline != std::string::npos)
+  private:
+    static size_t FindNewline(const std::string& str, size_t start)
     {
-      StoreLine(str, start, newline, res);
-      start = MoveToNextLine(str, newline);
-      newline = FindNewline(str, start);
+      return str.find_first_of("\r\n", start);
     }
 
-    if(start < str.size())
+    static void StoreLine(const std::string& str, size_t start, size_t end,
+        std::vector<std::string>& res)
     {
-      StoreLine(str, start, std::string::npos, res);
-    }
-  }
-
-private:
-  static size_t FindNewline(const std::string& str, size_t start)
-  {
-    return str.find_first_of("\r\n", start);
-  }
-
-  static void StoreLine(const std::string& str, size_t start, size_t end,
-      std::vector<std::string>& res)
-  {
-    std::string line = str.substr(start, end - start);
-    res.push_back(line);
-  }
-
-  static size_t MoveToNextLine(const std::string& str, size_t newline)
-  {
-    if(str.find("\r\n", newline) == newline)
-    {
-      return newline + 2;
+      std::string line = str.substr(start, end - start);
+      res.push_back(line);
     }
 
-    if(str.find("\n", newline) == newline)
+    static size_t MoveToNextLine(const std::string& str, size_t newline)
     {
-      return newline + 1;
+      if(str.find("\r\n", newline) == newline)
+      {
+        return newline + 2;
+      }
+
+      if(str.find("\n", newline) == newline)
+      {
+        return newline + 1;
+      }
+
+      if(str.find("\r", newline) == newline)
+      {
+        return newline + 1;
+      }
+
+      std::ostringstream stm;
+      stm << "This string seems to contain an invalid line ending at position "
+          << newline << ":\n" << str << std::endl;
+      throw InvalidExpressionException(stm.str());
     }
+  };
 
-    if(str.find("\r", newline) == newline)
-    {
-      return newline + 1;
-    }
-
-    std::ostringstream stm;
-    stm << "This string seems to contain an invalid line ending at position "
-        << newline << ":\n" << str << std::endl;
-    throw InvalidExpressionException(stm.str());
-  }
-};
-
-template<typename ConstraintListType>
-struct CollectionConstraintEvaluator<ConstraintListType, std::string>
-{
-  static unsigned int Evaluate(const ConstraintOperator& op,
-      ConstraintListType& expression, ResultStack& result,
-      OperatorStack& operators, const std::string& actual)
+  template<typename ConstraintListType>
+  struct CollectionConstraintEvaluator<ConstraintListType, std::string>
   {
-    std::vector<std::string> lines;
-    StringLineParser::Parse(actual, lines);
-    return CollectionConstraintEvaluator<ConstraintListType, std::vector<std::string> >::Evaluate(op, expression, result, operators, lines);
-  }
-};
+    static unsigned int Evaluate(const ConstraintOperator& op,
+        ConstraintListType& expression, ResultStack& result,
+        OperatorStack& operators, const std::string& actual)
+    {
+      std::vector<std::string> lines;
+      StringLineParser::Parse(actual, lines);
+      return CollectionConstraintEvaluator<ConstraintListType, std::vector<std::string> >::Evaluate(op, expression, result, operators, lines);
+    }
+  };
 
 }
 

--- a/snowhouse/fluent/operators/collections/collectionoperator.h
+++ b/snowhouse/fluent/operators/collections/collectionoperator.h
@@ -11,9 +11,7 @@
 namespace snowhouse {
   struct CollectionOperator : public ConstraintOperator
   {
-    void PerformOperation(ResultStack&)
-    {
-    }
+    void PerformOperation(ResultStack&) {}
 
     int Precedence() const
     {

--- a/snowhouse/fluent/operators/collections/collectionoperator.h
+++ b/snowhouse/fluent/operators/collections/collectionoperator.h
@@ -9,17 +9,17 @@
 #include "../constraintoperator.h"
 
 namespace snowhouse {
-   struct CollectionOperator : public ConstraintOperator
-   {
-      void PerformOperation(ResultStack&)
-      {
-      }
+  struct CollectionOperator : public ConstraintOperator
+  {
+    void PerformOperation(ResultStack&)
+    {
+    }
 
-      int Precedence() const
-      {
-         return 1;
-      }
-   };
+    int Precedence() const
+    {
+      return 1;
+    }
+  };
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/collectionoperator.h
+++ b/snowhouse/fluent/operators/collections/collectionoperator.h
@@ -8,8 +8,8 @@
 
 #include "../constraintoperator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct CollectionOperator : public ConstraintOperator
   {
     void PerformOperation(ResultStack&) {}

--- a/snowhouse/fluent/operators/collections/collectionoperator.h
+++ b/snowhouse/fluent/operators/collections/collectionoperator.h
@@ -12,7 +12,9 @@ namespace snowhouse
 {
   struct CollectionOperator : public ConstraintOperator
   {
-    void PerformOperation(ResultStack&) {}
+    void PerformOperation(ResultStack&)
+    {
+    }
 
     int Precedence() const
     {

--- a/snowhouse/fluent/operators/collections/collectionoperator.h
+++ b/snowhouse/fluent/operators/collections/collectionoperator.h
@@ -9,6 +9,7 @@
 #include "../constraintoperator.h"
 
 namespace snowhouse {
+
   struct CollectionOperator : public ConstraintOperator
   {
     void PerformOperation(ResultStack&) {}

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -9,8 +9,8 @@
 #include "collectionoperator.h"
 #include "collectionconstraintevaluator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct ExactlyOperator : public CollectionOperator
   {
     explicit ExactlyOperator(unsigned int expected) : m_expected(expected) {}

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -15,7 +15,7 @@ namespace snowhouse {
   {
     explicit ExactlyOperator(unsigned int expected) : m_expected(expected) {}
 
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -14,7 +14,7 @@ namespace snowhouse
   struct ExactlyOperator : public CollectionOperator
   {
     explicit ExactlyOperator(unsigned int expected)
-      : m_expected(expected)
+        : m_expected(expected)
     {
     }
 

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -27,7 +27,7 @@ namespace snowhouse {
   };
 
   template<>
-  struct Stringizer< ExactlyOperator >
+  struct Stringizer<ExactlyOperator>
   {
     static std::string ToString(const ExactlyOperator& op)
     {

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -13,7 +13,10 @@ namespace snowhouse
 {
   struct ExactlyOperator : public CollectionOperator
   {
-    explicit ExactlyOperator(unsigned int expected) : m_expected(expected) {}
+    explicit ExactlyOperator(unsigned int expected)
+      : m_expected(expected)
+    {
+    }
 
     template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -11,31 +11,31 @@
 
 namespace snowhouse {
 
-   struct ExactlyOperator : public CollectionOperator
-   {
-      explicit ExactlyOperator(unsigned int expected) : m_expected(expected) {}
+  struct ExactlyOperator : public CollectionOperator
+  {
+    explicit ExactlyOperator(unsigned int expected) : m_expected(expected) {}
 
-      template <typename ConstraintListType, typename ActualType>
-      void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
-      {
-         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+    template <typename ConstraintListType, typename ActualType>
+    void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
+    {
+      unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
-         result.push(passed_elements == m_expected);
-      }
+      result.push(passed_elements == m_expected);
+    }
 
-      unsigned int m_expected;
-   };
+    unsigned int m_expected;
+  };
 
-   template<>
-   struct Stringizer< ExactlyOperator >
-   {
-      static std::string ToString(const ExactlyOperator& op)
-      {
-         std::ostringstream stm;
-         stm << "exactly " << op.m_expected;
-         return stm.str();
-      }
-   };
+  template<>
+  struct Stringizer< ExactlyOperator >
+  {
+    static std::string ToString(const ExactlyOperator& op)
+    {
+      std::ostringstream stm;
+      stm << "exactly " << op.m_expected;
+      return stm.str();
+    }
+  };
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/exactlyoperator.h
+++ b/snowhouse/fluent/operators/collections/exactlyoperator.h
@@ -18,7 +18,7 @@ namespace snowhouse {
       template <typename ConstraintListType, typename ActualType>
       void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
       {
-        unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
 
          result.push(passed_elements == m_expected);
       }
@@ -26,16 +26,16 @@ namespace snowhouse {
       unsigned int m_expected;
    };
 
-  template<>
-  struct Stringizer< ExactlyOperator >
-  {
-    static std::string ToString(const ExactlyOperator& op)
-    {
-      std::ostringstream stm;
-      stm << "exactly " << op.m_expected;
-      return stm.str();
-    }
-  };
+   template<>
+   struct Stringizer< ExactlyOperator >
+   {
+      static std::string ToString(const ExactlyOperator& op)
+      {
+         std::ostringstream stm;
+         stm << "exactly " << op.m_expected;
+         return stm.str();
+      }
+   };
 }
 
 #endif

--- a/snowhouse/fluent/operators/collections/noneoperator.h
+++ b/snowhouse/fluent/operators/collections/noneoperator.h
@@ -9,8 +9,8 @@
 #include "collectionoperator.h"
 #include "collectionconstraintevaluator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct NoneOperator : public CollectionOperator
   {
     template<typename ConstraintListType, typename ActualType>

--- a/snowhouse/fluent/operators/collections/noneoperator.h
+++ b/snowhouse/fluent/operators/collections/noneoperator.h
@@ -13,7 +13,7 @@ namespace snowhouse {
 
   struct NoneOperator : public CollectionOperator
   {
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);

--- a/snowhouse/fluent/operators/collections/noneoperator.h
+++ b/snowhouse/fluent/operators/collections/noneoperator.h
@@ -11,24 +11,24 @@
 
 namespace snowhouse {
 
-   struct NoneOperator : public CollectionOperator
-   {
-      template <typename ConstraintListType, typename ActualType>
-      void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
-      {
-         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
-         result.push(passed_elements == 0);
-      }
-   };
+  struct NoneOperator : public CollectionOperator
+  {
+    template <typename ConstraintListType, typename ActualType>
+    void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
+    {
+      unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+      result.push(passed_elements == 0);
+    }
+  };
 
-   template<>
-   struct Stringizer<NoneOperator>
-   {
-      static std::string ToString(const NoneOperator&)
-      {
-         return "none";
-      }
-   };
+  template<>
+  struct Stringizer<NoneOperator>
+  {
+    static std::string ToString(const NoneOperator&)
+    {
+      return "none";
+    }
+  };
 
 }
 

--- a/snowhouse/fluent/operators/collections/noneoperator.h
+++ b/snowhouse/fluent/operators/collections/noneoperator.h
@@ -16,8 +16,8 @@ namespace snowhouse {
       template <typename ConstraintListType, typename ActualType>
       void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
       {
-        unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
-        result.push(passed_elements == 0);
+         unsigned int passed_elements = CollectionConstraintEvaluator<ConstraintListType, ActualType>::Evaluate(*this, list, result, operators, actual);
+         result.push(passed_elements == 0);
       }
    };
 

--- a/snowhouse/fluent/operators/collections/noneoperator.h
+++ b/snowhouse/fluent/operators/collections/noneoperator.h
@@ -29,7 +29,6 @@ namespace snowhouse {
       return "none";
     }
   };
-
 }
 
 #endif

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -22,7 +22,7 @@ namespace snowhouse {
     virtual void PerformOperation(ResultStack& result) = 0;
     virtual int Precedence() const = 0;
 
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     static bool EvaluateElementAgainstRestOfExpression(ConstraintListType& list, const ActualType& actual)
     {
       ResultStack innerResult;

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -65,7 +65,6 @@ namespace snowhouse {
       }
     }
   };
-
 }
 
 #endif

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -25,18 +25,18 @@ namespace snowhouse {
     template <typename ConstraintListType, typename ActualType>
     static bool EvaluateElementAgainstRestOfExpression(ConstraintListType& list, const ActualType& actual)
     {
-       ResultStack innerResult;
-       OperatorStack innerOperators;
+      ResultStack innerResult;
+      OperatorStack innerOperators;
 
-       EvaluateConstraintList(list.m_tail, innerResult, innerOperators, actual);
-       EvaluateAllOperatorsOnStack(innerOperators, innerResult);
+      EvaluateConstraintList(list.m_tail, innerResult, innerOperators, actual);
+      EvaluateAllOperatorsOnStack(innerOperators, innerResult);
 
-       if(innerResult.empty())
-       {
-         throw InvalidExpressionException("The expression after \"" + snowhouse::Stringize(list.m_head) + "\" operator does not yield any result");
-       }
+      if(innerResult.empty())
+      {
+        throw InvalidExpressionException("The expression after \"" + snowhouse::Stringize(list.m_head) + "\" operator does not yield any result");
+      }
 
-       return innerResult.top();
+      return innerResult.top();
     }
 
     static void EvaluateOperatorsWithLessOrEqualPrecedence(const ConstraintOperator& op, OperatorStack& operators, ResultStack& result)

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -14,9 +14,10 @@ namespace snowhouse
 {
   struct ConstraintOperator
   {
-#if __cplusplus > 199711L
-#else
-    virtual ~ConstraintOperator() {}
+#if __cplusplus <= 199711L
+    virtual ~ConstraintOperator()
+    {
+    }
 #endif
 
     virtual void PerformOperation(ResultStack& result) = 0;

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -31,7 +31,7 @@ namespace snowhouse {
       EvaluateConstraintList(list.m_tail, innerResult, innerOperators, actual);
       EvaluateAllOperatorsOnStack(innerOperators, innerResult);
 
-      if(innerResult.empty())
+      if (innerResult.empty())
       {
         throw InvalidExpressionException("The expression after \"" + snowhouse::Stringize(list.m_head) + "\" operator does not yield any result");
       }
@@ -41,11 +41,11 @@ namespace snowhouse {
 
     static void EvaluateOperatorsWithLessOrEqualPrecedence(const ConstraintOperator& op, OperatorStack& operators, ResultStack& result)
     {
-      while(!operators.empty())
+      while (!operators.empty())
       {
         ConstraintOperator* op_from_stack = operators.top();
 
-        if(op_from_stack->Precedence() > op.Precedence())
+        if (op_from_stack->Precedence() > op.Precedence())
         {
           break;
         }
@@ -57,7 +57,7 @@ namespace snowhouse {
 
     static void EvaluateAllOperatorsOnStack(OperatorStack& operators, ResultStack& result)
     {
-      while(!operators.empty())
+      while (!operators.empty())
       {
         ConstraintOperator* op = operators.top();
         op->PerformOperation(result);

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -10,8 +10,8 @@
 #include "../constraintlist.h"
 #include "invalidexpressionexception.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct ConstraintOperator
   {
 #if __cplusplus > 199711L

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -13,7 +13,7 @@ namespace snowhouse
   struct InvalidExpressionException
   {
     explicit InvalidExpressionException(const std::string& message)
-      : m_message(message)
+        : m_message(message)
     {
     }
 

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -13,7 +13,9 @@ namespace snowhouse
   struct InvalidExpressionException
   {
     explicit InvalidExpressionException(const std::string& message)
-      : m_message(message) {}
+      : m_message(message)
+    {
+    }
 
     const std::string& Message() const
     {

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -8,8 +8,8 @@
 
 #include <string>
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct InvalidExpressionException
   {
     explicit InvalidExpressionException(const std::string& message)

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -22,7 +22,6 @@ namespace snowhouse {
 
     std::string m_message;
   };
-
 }
 
 #endif // SNOWHOUSE_INVALUDEXPRESSIONEXCEPTION_H

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -12,9 +12,8 @@ namespace snowhouse {
 
   struct InvalidExpressionException
   {
-    explicit InvalidExpressionException(const std::string& message) : m_message(message)
-    {
-    }
+    explicit InvalidExpressionException(const std::string& message)
+      : m_message(message) {}
 
     const std::string& Message() const
     {

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -24,4 +24,4 @@ namespace snowhouse {
   };
 }
 
-#endif // SNOWHOUSE_INVALUDEXPRESSIONEXCEPTION_H
+#endif

--- a/snowhouse/fluent/operators/notoperator.h
+++ b/snowhouse/fluent/operators/notoperator.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_NOTOPERATOR_H
 #define SNOWHOUSE_NOTOPERATOR_H
 
-#include "./constraintoperator.h"
+#include "constraintoperator.h"
 
 namespace snowhouse
 {

--- a/snowhouse/fluent/operators/notoperator.h
+++ b/snowhouse/fluent/operators/notoperator.h
@@ -8,8 +8,8 @@
 
 #include "./constraintoperator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct NotOperator : public ConstraintOperator
   {
     template<typename ConstraintListType, typename ActualType>

--- a/snowhouse/fluent/operators/notoperator.h
+++ b/snowhouse/fluent/operators/notoperator.h
@@ -24,7 +24,7 @@ namespace snowhouse {
 
     void PerformOperation(ResultStack& result)
     {
-      if(result.size() < 1)
+      if (result.size() < 1)
       {
         throw InvalidExpressionException("The expression contains a not operator without any operand");
       }

--- a/snowhouse/fluent/operators/notoperator.h
+++ b/snowhouse/fluent/operators/notoperator.h
@@ -41,14 +41,14 @@ namespace snowhouse {
     }
   };
 
-   template<>
-   struct Stringizer<NotOperator>
-   {
-      static std::string ToString(const NotOperator&)
-      {
-         return "not";
-      }
-   };
+  template<>
+  struct Stringizer<NotOperator>
+  {
+    static std::string ToString(const NotOperator&)
+    {
+      return "not";
+    }
+  };
 }
 
 #endif

--- a/snowhouse/fluent/operators/notoperator.h
+++ b/snowhouse/fluent/operators/notoperator.h
@@ -12,7 +12,7 @@ namespace snowhouse {
 
   struct NotOperator : public ConstraintOperator
   {
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       EvaluateOperatorsWithLessOrEqualPrecedence(*this, operators, result);

--- a/snowhouse/fluent/operators/oroperator.h
+++ b/snowhouse/fluent/operators/oroperator.h
@@ -12,7 +12,7 @@ namespace snowhouse {
 
   struct OrOperator : public ConstraintOperator
   {
-    template <typename ConstraintListType, typename ActualType>
+    template<typename ConstraintListType, typename ActualType>
     void Evaluate(ConstraintListType& list, ResultStack& result, OperatorStack& operators, const ActualType& actual)
     {
       EvaluateOperatorsWithLessOrEqualPrecedence(*this, operators, result);

--- a/snowhouse/fluent/operators/oroperator.h
+++ b/snowhouse/fluent/operators/oroperator.h
@@ -6,7 +6,7 @@
 #ifndef SNOWHOUSE_OROPERATOR_H
 #define SNOWHOUSE_OROPERATOR_H
 
-#include "./constraintoperator.h"
+#include "constraintoperator.h"
 
 namespace snowhouse
 {

--- a/snowhouse/fluent/operators/oroperator.h
+++ b/snowhouse/fluent/operators/oroperator.h
@@ -24,7 +24,7 @@ namespace snowhouse {
 
     void PerformOperation(ResultStack& result)
     {
-      if(result.size() < 2)
+      if (result.size() < 2)
       {
         throw InvalidExpressionException("The expression contains an or operator with too few operands");
       }

--- a/snowhouse/fluent/operators/oroperator.h
+++ b/snowhouse/fluent/operators/oroperator.h
@@ -8,8 +8,8 @@
 
 #include "./constraintoperator.h"
 
-namespace snowhouse {
-
+namespace snowhouse
+{
   struct OrOperator : public ConstraintOperator
   {
     template<typename ConstraintListType, typename ActualType>

--- a/snowhouse/macros.h
+++ b/snowhouse/macros.h
@@ -1,5 +1,6 @@
 #ifndef SNOWHOUSE_MACROS_H
 #define SNOWHOUSE_MACROS_H
+// clang-format off
 
 #define SNOWHOUSE_VERSION "2.1.0"
 

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -26,7 +26,9 @@ namespace snowhouse
 
     // A tag type returned by operator<< for the any struct in this namespace
     // when T does not support <<.
-    struct tag {};
+    struct tag
+    {
+    };
 
     // Fallback operator<< for types T that don't support <<.
     tag operator<<(std::ostream&, any const&);

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -86,7 +86,7 @@ namespace snowhouse {
   {
     static std::string ToString(const T& value)
     {
-      return detail::DefaultStringizer< T, detail::is_output_streamable<T>::value >::ToString(value);
+      return detail::DefaultStringizer<T, detail::is_output_streamable<T>::value>::ToString(value);
     }
   };
 

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -12,6 +12,7 @@
 #include "macros.h"
 
 namespace snowhouse {
+
   namespace detail {
 
     // This type soaks up any implicit conversions and makes the following operator<<

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -19,7 +19,7 @@ namespace snowhouse {
     struct any
     {
       // Conversion constructor for any type.
-      template <class T>
+      template <typename T>
       any(T const&);
     };
 
@@ -40,10 +40,10 @@ namespace snowhouse {
 
     no check(tag);
 
-    template <class T>
+    template <typename T>
     yes check(T const&);
 
-    template <class T>
+    template <typename T>
     struct is_output_streamable
     {
       static const T& x;

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -19,7 +19,7 @@ namespace snowhouse {
     struct any
     {
       // Conversion constructor for any type.
-      template <typename T>
+      template<typename T>
       any(T const&);
     };
 
@@ -40,10 +40,10 @@ namespace snowhouse {
 
     no check(tag);
 
-    template <typename T>
+    template<typename T>
     yes check(T const&);
 
-    template <typename T>
+    template<typename T>
     struct is_output_streamable
     {
       static const T& x;

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -11,10 +11,10 @@
 
 #include "macros.h"
 
-namespace snowhouse {
-
-  namespace detail {
-
+namespace snowhouse
+{
+  namespace detail
+  {
     // This type soaks up any implicit conversions and makes the following operator<<
     // less preferred than any other such operator found via ADL.
     struct any

--- a/snowhouse/stringizers.h
+++ b/snowhouse/stringizers.h
@@ -12,11 +12,9 @@
 
 #include "stringize.h"
 
-namespace snowhouse
-{
+namespace snowhouse {
 
-  namespace detail
-  {
+  namespace detail {
 
     template<typename Container>
     struct SequentialContainerStringizer

--- a/snowhouse/stringizers.h
+++ b/snowhouse/stringizers.h
@@ -12,10 +12,10 @@
 
 #include "stringize.h"
 
-namespace snowhouse {
-
-  namespace detail {
-
+namespace snowhouse
+{
+  namespace detail
+  {
     template<typename Container>
     struct SequentialContainerStringizer
     {

--- a/snowhouse/stringizers.h
+++ b/snowhouse/stringizers.h
@@ -19,47 +19,47 @@ namespace snowhouse
   {
 
     template<typename Container>
-      struct SequentialContainerStringizer
+    struct SequentialContainerStringizer
+    {
+      static std::string
+      ToString(const Container& cont)
       {
-        static std::string
-        ToString(const Container& cont)
+        std::ostringstream stm;
+        typedef typename Container::const_iterator Iterator;
+
+        stm << "[ ";
+        for (Iterator it = cont.begin(); it != cont.end();)
         {
-          std::ostringstream stm;
-          typedef typename Container::const_iterator Iterator;
+          stm << snowhouse::Stringize(*it);
 
-          stm << "[ ";
-          for (Iterator it = cont.begin(); it != cont.end();)
+          if (++it != cont.end())
           {
-            stm << snowhouse::Stringize(*it);
-
-            if (++it != cont.end())
-            {
-              stm << ", ";
-            }
+            stm << ", ";
           }
-          stm << " ]";
-          return stm.str();
         }
-      };
+        stm << " ]";
+        return stm.str();
+      }
+    };
   }
 
   template<typename T>
-    struct Stringizer<std::vector<T> > : detail::SequentialContainerStringizer<
-        std::vector<T> >
-    {
-    };
+  struct Stringizer<std::vector<T> > : detail::SequentialContainerStringizer<
+      std::vector<T> >
+  {
+  };
 
   template<typename T>
-    struct Stringizer<std::deque<T> > : detail::SequentialContainerStringizer<
-        std::deque<T> >
-    {
-    };
+  struct Stringizer<std::deque<T> > : detail::SequentialContainerStringizer<
+      std::deque<T> >
+  {
+  };
 
   template<typename T>
-    struct Stringizer<std::list<T> > : detail::SequentialContainerStringizer<
-        std::list<T> >
-    {
-    };
+  struct Stringizer<std::list<T> > : detail::SequentialContainerStringizer<
+      std::list<T> >
+  {
+  };
 }
 
 #endif

--- a/snowhouse/stringizers.h
+++ b/snowhouse/stringizers.h
@@ -44,22 +44,16 @@ namespace snowhouse
   }
 
   template<typename T>
-  struct Stringizer<std::vector<T> > : detail::SequentialContainerStringizer<
-      std::vector<T> >
-  {
-  };
+  struct Stringizer<std::vector<T> >
+    : detail::SequentialContainerStringizer<std::vector<T> > {};
 
   template<typename T>
-  struct Stringizer<std::deque<T> > : detail::SequentialContainerStringizer<
-      std::deque<T> >
-  {
-  };
+  struct Stringizer<std::deque<T> >
+    : detail::SequentialContainerStringizer<std::deque<T> > {};
 
   template<typename T>
-  struct Stringizer<std::list<T> > : detail::SequentialContainerStringizer<
-      std::list<T> >
-  {
-  };
+  struct Stringizer<std::list<T> >
+    : detail::SequentialContainerStringizer<std::list<T> > {};
 }
 
 #endif

--- a/snowhouse/stringizers.h
+++ b/snowhouse/stringizers.h
@@ -43,15 +43,21 @@ namespace snowhouse
 
   template<typename T>
   struct Stringizer<std::vector<T> >
-    : detail::SequentialContainerStringizer<std::vector<T> > {};
+      : detail::SequentialContainerStringizer<std::vector<T> >
+  {
+  };
 
   template<typename T>
   struct Stringizer<std::deque<T> >
-    : detail::SequentialContainerStringizer<std::deque<T> > {};
+      : detail::SequentialContainerStringizer<std::deque<T> >
+  {
+  };
 
   template<typename T>
   struct Stringizer<std::list<T> >
-    : detail::SequentialContainerStringizer<std::list<T> > {};
+      : detail::SequentialContainerStringizer<std::list<T> >
+  {
+  };
 }
 
 #endif


### PR DESCRIPTION
Beginning with this, I want to be more strict regarding new
contributions. A consistent coding style is useful to improve
readability.

Apart from very few things, the overall style of the snowhouse
codebase now adheres to the style of the snowhouse codebase
majority. A `.clang-format` file is added as a service for new
contributions, however, it is not 100% accurate due to limitations
of the clang-format tool.