### PR TITLE
Fix macros broken if namespace std exists in current namespace.

### DIFF
--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -100,13 +100,13 @@ namespace snowhouse
   } \
   if (SNOWHOUSE_TEMPVAR(no_exception)) \
   { \
-    std::ostringstream stm; \
+    ::std::ostringstream stm;					     \
     stm << "Expected " #EXCEPTION_TYPE ". No exception was thrown."; \
     ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \
   if (SNOWHOUSE_TEMPVAR(wrong_exception)) \
   { \
-    std::ostringstream stm; \
+    ::std::ostringstream stm;						\
     stm << "Expected " #EXCEPTION_TYPE ". Wrong exception was thrown."; \
     ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \


### PR DESCRIPTION
If the macro is used in a namespace that contains the namespace std (that is not the compiler library std), the current macro breaks.  Add `::` to fix this.