### PR TITLE
snowhouse/macros.h: Allow noexcept with clang-cl

### DIFF
--- a/snowhouse/macros.h
+++ b/snowhouse/macros.h
@@ -15,7 +15,7 @@
 
 #if __cplusplus > 199711L
 // Visual Studio (including 2013) does not support the noexcept keyword
-# ifdef _MSC_VER
+# if defined(_MSC_VER) && !defined(__clang__)
 #  define _ALLOW_KEYWORD_MACROS
 #  define noexcept
 # endif


### PR DESCRIPTION
This allows compiling snowhouse (and thus bandit) when using the `clang-cl` compiler on Windows.

Very strange things happen (static assertions failing in `stack` for example) without this when using `clang-cl`, as it supports `noexcept` but it has been `#define`d away. Took me a while to track it down to here.