### PR TITLE
Fix zero as null pointer constant warning

### DIFF
--- a/include/snowhouse/stringizers.h
+++ b/include/snowhouse/stringizers.h
@@ -48,7 +48,11 @@ namespace snowhouse
       template<typename>
       static no compile_time_check_const_iterator(...);
 
+#ifdef SNOWHOUSE_HAS_NULLPTR
+      static const bool value = sizeof(compile_time_check_const_iterator<T>(nullptr)) == sizeof(yes);
+#else
       static const bool value = sizeof(compile_time_check_const_iterator<T>(0)) == sizeof(yes);
+#endif
     };
 
     template<typename T, bool = is_const_iterable<T>::value>


### PR DESCRIPTION
This PR simply replace 0 or NULL by nullptr. It allow compiling the code with the following compiler flags:

```
-Werror -Wzero-as-null-pointer-constant
```
