### PR TITLE
Improve display of bools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linux-build-test:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,6 @@
 name: Test coding style
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/include/snowhouse/stringize.h
+++ b/include/snowhouse/stringize.h
@@ -75,6 +75,15 @@ namespace snowhouse
       }
     };
 
+    template<>
+    struct DefaultStringizer<bool, true>
+    {
+      static std::string ToString(bool value)
+      {
+        return value ? "true" : "false";
+      }
+    };
+
     template<typename T>
     struct DefaultStringizer<T, false>
     {


### PR DESCRIPTION
Consider the following example:
```cpp
#include <bandit/bandit.h>

go_bandit([] {
  bandit::describe("example", [] {
    bandit::it("false is not true", [] {
      AssertThat(false, snowhouse::Is().True());
    });
    bandit::it("true is not false", [] {
      AssertThat(true, snowhouse::Is().False());
    });
  });
});

int main(int argc, char** argv) {
  return bandit::run(argc, argv);
}
```

Obviously the tests fail but messages are:
```
FF
There were failures!

example false is not true:
a.cpp:6: Expected: true
Actual: 0


example true is not false:
a.cpp:9: Expected: false
Actual: 1

Test run complete. 2 tests run. 0 succeeded. 2 failed.
```

`true` and `false` are respectively printed as `1` and `0`.

To fix this, `std::boolalpha` is added.