### PR TITLE
 If we catch the wrong exception in AssertThrows, print the description of the exception

### DIFF
--- a/example/exceptions_tests.cpp
+++ b/example/exceptions_tests.cpp
@@ -26,6 +26,14 @@ struct ClassWithExceptions
   }
 };
 
+struct ExpectedException : public std::exception
+{
+  const char* what() const throw()
+  {
+    return "Description of the exception we expected";
+  }
+};
+
 void ExceptionTests()
 {
   ClassWithExceptions objectUnderTest;
@@ -88,5 +96,10 @@ void ExceptionTests()
     }
     AssertThrows(AssertionException, LastException<std::logic_error>());
     AssertThat(LastException<AssertionException>().GetMessage(), Contains("No exception was stored"));
+  }
+
+  it("prints description of unwanted exception");
+  {
+    AssertTestFails(AssertThrows(ExpectedException, objectUnderTest.LogicError()), "Expected ExpectedException. Wrong exception was thrown. Description of unwanted exception: not logical!");
   }
 }

--- a/include/snowhouse/exceptions.h
+++ b/include/snowhouse/exceptions.h
@@ -85,6 +85,8 @@ namespace snowhouse
   SNOWHOUSE_TEMPVAR(storage).compiler_thinks_i_am_unused(); \
   bool SNOWHOUSE_TEMPVAR(wrong_exception) = false; \
   bool SNOWHOUSE_TEMPVAR(no_exception) = false; \
+  bool SNOWHOUSE_TEMPVAR(more_info) = true; \
+  std::string SNOWHOUSE_TEMPVAR(info_string); \
   try \
   { \
     METHOD; \
@@ -97,6 +99,14 @@ namespace snowhouse
   catch (...) \
   { \
     SNOWHOUSE_TEMPVAR(wrong_exception) = true; \
+    if (auto eptr = std::current_exception()) { \
+      try { \
+        std::rethrow_exception(eptr); \
+      } catch (const std::exception& e) { \
+        SNOWHOUSE_TEMPVAR(more_info) = true; \
+        SNOWHOUSE_TEMPVAR(info_string) = e.what(); \
+      } catch (...) {} \
+    } \
   } \
   if (SNOWHOUSE_TEMPVAR(no_exception)) \
   { \
@@ -108,6 +118,9 @@ namespace snowhouse
   { \
     ::std::ostringstream SNOWHOUSE_TEMPVAR(stm); \
     SNOWHOUSE_TEMPVAR(stm) << "Expected " #EXCEPTION_TYPE ". Wrong exception was thrown."; \
+    if (SNOWHOUSE_TEMPVAR(more_info)) { \
+      SNOWHOUSE_TEMPVAR(stm) << " Description of unwanted exception: " << SNOWHOUSE_TEMPVAR(info_string); \
+    } \
     ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(SNOWHOUSE_TEMPVAR(stm).str()); \
   } \
   do {} while (false)


### PR DESCRIPTION
This makes it easier to debug the failure

fixes #47